### PR TITLE
Add endpoint for verifying and invalidating records

### DIFF
--- a/src/app/framework/utils/status-label.util.ts
+++ b/src/app/framework/utils/status-label.util.ts
@@ -15,7 +15,6 @@
  * @returns Label traduzido
  */
 export function getNadaConstaStatusLabel(status: string): string {
-  if (!status) return '';
   switch (status) {
     case 'PENDENTE':
     case 'PENDING':
@@ -27,6 +26,9 @@ export function getNadaConstaStatusLabel(status: string): string {
     case 'FAILED':
     case 'FALHA':
       return 'FALHA';
+    case 'INVALIDADO':
+    case 'INVALIDATED':
+      return 'INVALIDADO';
     default:
       return status;
   }
@@ -38,7 +40,6 @@ export function getNadaConstaStatusLabel(status: string): string {
  * @returns 'warn' | 'success' | 'danger'
  */
 export function getNadaConstaStatusSeverity(status: string): 'warn' | 'success' | 'danger' {
-  if (!status) return 'warn';
   switch (status) {
     case 'PENDENTE':
     case 'PENDING':
@@ -50,8 +51,10 @@ export function getNadaConstaStatusSeverity(status: string): 'warn' | 'success' 
     case 'FAILED':
     case 'FALHA':
       return 'danger';
+    case 'INVALIDADO':
+    case 'INVALIDATED':
+      return 'danger';
     default:
       return 'warn';
   }
 }
-

--- a/src/app/nada-consta/list/nada-consta-list.component.html
+++ b/src/app/nada-consta/list/nada-consta-list.component.html
@@ -65,8 +65,34 @@
         </form>
       </p-dialog>
 
+      <!-- Dialog de Confirmação de Invalidação -->
+      <p-dialog
+        header="Confirmar Invalidação"
+        [visible]="showConfirmInvalidar()"
+        (onHide)="cancelarInvalidar()"
+        [modal]="true"
+        [closable]="true"
+        [style]="{width: '400px'}"
+        [baseZIndex]="1200"
+        [dismissableMask]="true"
+        [blockScroll]="true"
+        [contentStyle]="{padding: '1.5rem'}"
+        [focusOnShow]="false">
+        <div class="p-fluid">
+          <p class="mb-3">Deseja realmente invalidar o Nada Consta?
+            <br>
+            <strong>ID:</strong> {{ registroParaInvalidar()?.id }}<br>
+            <strong>Usuário:</strong> {{ registroParaInvalidar()?.usuario?.nome }}
+          </p>
+          <div class="flex justify-end gap-2 mt-4">
+            <button pButton type="button" label="Cancelar" class="p-button-text" (click)="cancelarInvalidar()" [disabled]="invalidando() === registroParaInvalidar()?.id"></button>
+            <button pButton type="button" label="Confirmar" class="p-button-danger" (click)="confirmarInvalidar()" [disabled]="invalidando() === registroParaInvalidar()?.id"></button>
+          </div>
+        </div>
+      </p-dialog>
+
       @if (loading()) {
-        <p-progressBar mode="indeterminate" style="height: 6px"></p-progressBar>
+        <p-progressBar mode="indeterminate" [style.height]="'6px'"></p-progressBar>
       }
 
       <p-table
@@ -128,11 +154,27 @@
                   @case ('acoes') {
                     <div class="flex justify-between gap-2">
                       @switch (getStatusLabel(row.status)) {
-                        @case ('EMITIDO') {
-                          <p-button icon="pi pi-send" class="p-button-text p-button-rounded" pTooltip="Reenviar Nada Consta" tooltipPosition="top" (onClick)="reenviarNadaConsta(row)"></p-button>
-                        }
                         @case ('COM PENDÊNCIA') {
-                          <p-button icon="pi pi-refresh" class="p-button-text p-button-rounded" pTooltip="Atualizar Status" tooltipPosition="top" (onClick)="atualizarStatus(row)"></p-button>
+                          <p-button
+                            icon="pi pi-refresh"
+                            class="p-button-text p-button-rounded"
+                            pTooltip="Verificar Pendências"
+                            tooltipPosition="top"
+                            [loading]="verificandoPendencias() === row.id"
+                            (onClick)="verificarPendencias(row)"
+                            [attr.aria-label]="'Verificar pendências do registro ' + row.id"
+                          ></p-button>
+                        }
+                        @case ('EMITIDO') {
+                          <p-button
+                            icon="pi pi-ban"
+                            class="p-button-text p-button-rounded"
+                            pTooltip="Invalidar Nada Consta"
+                            tooltipPosition="top"
+                            [loading]="invalidando() === row.id"
+                            (onClick)="abrirDialogConfirmarInvalidar(row)"
+                            [attr.aria-label]="'Invalidar registro ' + row.id"
+                          ></p-button>
                         }
                       }
                     </div>

--- a/src/app/nada-consta/list/nada-consta-list.component.spec.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.spec.ts
@@ -17,7 +17,9 @@ describe('NadaConstaListComponent', () => {
     const serviceMock = {
       solicitar: jest.fn(),
       findAll: jest.fn().mockReturnValue(of([])),
-      findAllPaged: jest.fn().mockReturnValue(of([]))
+      findAllPaged: jest.fn().mockReturnValue(of([])),
+      verificarPendencias: jest.fn(),
+      invalidar: jest.fn()
     };
     await TestBed.configureTestingModule({
       providers: [
@@ -105,5 +107,97 @@ describe('NadaConstaListComponent', () => {
     const element = { id: 1 } as any;
     expect(() => component.reenviarNadaConsta(element)).not.toThrow();
     expect(() => component.atualizarStatus(element)).not.toThrow();
+  });
+
+  it('deve verificar pendências com sucesso', fakeAsync(() => {
+    const spy = jest.spyOn(component.getCdr(), 'markForCheck');
+    (service.verificarPendencias as jest.Mock) = jest.fn().mockReturnValueOnce(of({ id: 1 }));
+    const findAllSpy = jest.spyOn(component, 'findAll');
+    const row = { id: 1 } as any;
+    component.verificarPendencias(row);
+    tick();
+    expect(component.getVerificandoPendencias()).toBeNull();
+    expect(component.getAcaoSucesso()).toBe('Pendências verificadas com sucesso.');
+    expect(findAllSpy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('deve tratar erro ao verificar pendências', fakeAsync(() => {
+    const spy = jest.spyOn(component.getCdr(), 'markForCheck');
+    (service.verificarPendencias as jest.Mock) = jest.fn().mockReturnValueOnce(throwError(() => ({ error: { message: 'Erro ao verificar' } })));
+    const row = { id: 2 } as any;
+    component.verificarPendencias(row);
+    tick();
+    expect(component.getVerificandoPendencias()).toBeNull();
+    expect(component.getAcaoErro()).toBe('Erro ao verificar');
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('deve invalidar Nada Consta com sucesso', fakeAsync(() => {
+    const spy = jest.spyOn(component.getCdr(), 'markForCheck');
+    (service.invalidar as jest.Mock) = jest.fn().mockReturnValueOnce(of({ id: 3 }));
+    const findAllSpy = jest.spyOn(component, 'findAll');
+    const row = { id: 3 } as any;
+    component.invalidar(row);
+    tick();
+    expect(component.getInvalidando()).toBeNull();
+    expect(component.getAcaoSucesso()).toBe('Nada Consta invalidado com sucesso.');
+    expect(findAllSpy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('deve tratar erro ao invalidar Nada Consta', fakeAsync(() => {
+    const spy = jest.spyOn(component.getCdr(), 'markForCheck');
+    (service.invalidar as jest.Mock) = jest.fn().mockReturnValueOnce(throwError(() => ({ error: { message: 'Erro ao invalidar' } })));
+    const row = { id: 4 } as any;
+    component.invalidar(row);
+    tick();
+    expect(component.getInvalidando()).toBeNull();
+    expect(component.getAcaoErro()).toBe('Erro ao invalidar');
+    expect(spy).toHaveBeenCalled();
+  }));
+
+  it('deve abrir e cancelar dialog de confirmação de invalidar', () => {
+    const row = { id: 5 } as any;
+    component.abrirDialogConfirmarInvalidar(row);
+    expect(component.getShowConfirmInvalidar()).toBe(true);
+    expect(component.getRegistroParaInvalidar()).toEqual(row);
+    component.cancelarInvalidar();
+    expect(component.getShowConfirmInvalidar()).toBe(false);
+    expect(component.getRegistroParaInvalidar()).toBeNull();
+  });
+
+  it('deve confirmar invalidar e fechar dialog', fakeAsync(() => {
+    (service.invalidar as jest.Mock) = jest.fn().mockReturnValueOnce(of({ id: 6 }));
+    const spy = jest.spyOn(component, 'invalidar');
+    const row = { id: 6 } as any;
+    component.abrirDialogConfirmarInvalidar(row);
+    component.confirmarInvalidar();
+    tick();
+    expect(spy).toHaveBeenCalledWith(row);
+    expect(component.getShowConfirmInvalidar()).toBe(false);
+    expect(component.getRegistroParaInvalidar()).toBeNull();
+  }));
+
+  it('deve exibir botão de invalidar apenas para status EMITIDO', () => {
+    const getStatusLabel = component.getStatusLabel;
+    expect(getStatusLabel('COMPLETED')).toBe('EMITIDO');
+    expect(getStatusLabel('INVALIDADO')).toBe('INVALIDADO');
+    // Simula lógica do template
+    const showInvalidar = getStatusLabel('COMPLETED') === 'EMITIDO';
+    const hideInvalidar = getStatusLabel('INVALIDADO') === 'EMITIDO';
+    expect(showInvalidar).toBe(true);
+    expect(hideInvalidar).toBe(false);
+  });
+
+  it('deve controlar sinais de loading e feedback', () => {
+    component.setVerificandoPendencias(10);
+    expect(component.getVerificandoPendencias()).toBe(10);
+    component.setInvalidando(20);
+    expect(component.getInvalidando()).toBe(20);
+    component.setAcaoErro('erro');
+    expect(component.getAcaoErro()).toBe('erro');
+    component.setAcaoSucesso('sucesso');
+    expect(component.getAcaoSucesso()).toBe('sucesso');
   });
 });

--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -171,6 +171,42 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
     return this.solicitacaoSucesso();
   }
 
+  /**
+   * Getter público para o sinal showConfirmInvalidar
+   * @returns boolean
+   */
+  public getShowConfirmInvalidar() { return this.showConfirmInvalidar(); }
+
+  /**
+   * Getter público para o sinal registroParaInvalidar
+   * @returns NadaConsta | null
+   */
+  public getRegistroParaInvalidar() { return this.registroParaInvalidar(); }
+
+  /**
+   * Getter público para o sinal verificandoPendencias
+   * @returns boolean
+   */
+  public getVerificandoPendencias() { return this.verificandoPendencias(); }
+
+  /**
+   * Getter público para o sinal invalidando
+   * @returns boolean
+   */
+  public getInvalidando() { return this.invalidando(); }
+
+  /**
+   * Getter público para o sinal acaoErro
+   * @returns string | null
+   */
+  public getAcaoErro() { return this.acaoErro(); }
+
+  /**
+   * Getter público para o sinal acaoSucesso
+   * @returns string | null
+   */
+  public getAcaoSucesso() { return this.acaoSucesso(); }
+
   adicionar(): void {
     this.showAdicionarModal.set(true);
   }
@@ -332,4 +368,9 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
     this.showConfirmInvalidar.set(false);
     this.registroParaInvalidar.set(null);
   }
+
+  public setVerificandoPendencias(val: number | null) { this.verificandoPendencias.set(val); }
+  public setInvalidando(val: number | null) { this.invalidando.set(val); }
+  public setAcaoErro(val: string | null) { this.acaoErro.set(val); }
+  public setAcaoSucesso(val: string | null) { this.acaoSucesso.set(val); }
 }

--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -262,4 +262,74 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
   public override openForm(): void {
     this.showAdicionarModal.set(true);
   }
+
+  protected readonly verificandoPendencias = signal<number | null>(null);
+  protected readonly invalidando = signal<number | null>(null);
+  protected readonly acaoErro = signal<string | null>(null);
+  protected readonly acaoSucesso = signal<string | null>(null);
+
+  verificarPendencias(row: NadaConsta): void {
+    this.verificandoPendencias.set(row.id);
+    this.acaoErro.set(null);
+    this.acaoSucesso.set(null);
+    this.service.verificarPendencias(row.id)
+      .pipe(finalize(() => {
+        this.verificandoPendencias.set(null);
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: () => {
+          this.acaoSucesso.set('Pendências verificadas com sucesso.');
+          this.findAll();
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          this.acaoErro.set(err?.error?.message || 'Erro ao verificar pendências.');
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  invalidar(row: NadaConsta): void {
+    this.invalidando.set(row.id);
+    this.acaoErro.set(null);
+    this.acaoSucesso.set(null);
+    this.service.invalidar(row.id)
+      .pipe(finalize(() => {
+        this.invalidando.set(null);
+        this.cdr.markForCheck();
+      }))
+      .subscribe({
+        next: () => {
+          this.acaoSucesso.set('Nada Consta invalidado com sucesso.');
+          this.findAll();
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          this.acaoErro.set(err?.error?.message || 'Erro ao invalidar Nada Consta.');
+          this.cdr.markForCheck();
+        }
+      });
+  }
+
+  protected readonly showConfirmInvalidar = signal(false);
+  protected readonly registroParaInvalidar = signal<NadaConsta | null>(null);
+
+  abrirDialogConfirmarInvalidar(row: NadaConsta): void {
+    this.registroParaInvalidar.set(row);
+    this.showConfirmInvalidar.set(true);
+  }
+
+  cancelarInvalidar(): void {
+    this.showConfirmInvalidar.set(false);
+    this.registroParaInvalidar.set(null);
+  }
+
+  confirmarInvalidar(): void {
+    const registro = this.registroParaInvalidar();
+    if (!registro) return;
+    this.invalidar(registro);
+    this.showConfirmInvalidar.set(false);
+    this.registroParaInvalidar.set(null);
+  }
 }

--- a/src/app/nada-consta/nada-consta-visualizar.component.spec.ts
+++ b/src/app/nada-consta/nada-consta-visualizar.component.spec.ts
@@ -68,6 +68,66 @@ describe('NadaConstaVisualizarComponent', () => {
     expect(spy).toHaveBeenCalled();
   }));
 
+  it('deve iniciar com estado padrão', () => {
+    expect(component.id).toBeNull();
+    expect(component.resultado).toBeNull();
+    expect(component.erro).toBeNull();
+    expect(component.carregando).toBe(false);
+    expect(component.liveRegionText).toBe('');
+  });
+
+  it('deve exibir erro se id for zero', () => {
+    const spy = jest.spyOn(component.getCdr(), 'markForCheck');
+    component.id = 0;
+    (service.consultarNadaConsta as jest.Mock).mockReturnValueOnce(throwError(() => ({ error: { message: 'Não encontrado' } })));
+    component.consultar();
+    expect(component.erro).toBe('Não encontrado');
+    expect(component.resultado).toBeNull();
+    expect(component.liveRegionText).toBe('Não encontrado');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('deve exibir erro se id for negativo', () => {
+    const spy = jest.spyOn(component.getCdr(), 'markForCheck');
+    component.id = -1;
+    (service.consultarNadaConsta as jest.Mock).mockReturnValueOnce(throwError(() => ({ error: { message: 'Não encontrado' } })));
+    component.consultar();
+    expect(component.erro).toBe('Não encontrado');
+    expect(component.resultado).toBeNull();
+    expect(component.liveRegionText).toBe('Não encontrado');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('deve atualizar liveRegionText corretamente em consulta', fakeAsync(() => {
+    const mockNadaConsta: NadaConsta = {
+      id: 2,
+      usuario: { id: 2, nome: 'Outro', username: 'outro', documento: '', email: '', telefone: '', permissoes: [], fotoUrl: null, codigoVerificacao: '', ativo: true, authorities: [], accountNonExpired: true, accountNonLocked: true, credentialsNonExpired: true, enabled: true },
+      status: 'PENDENTE', sendAt: '', createdAt: '', updatedAt: '', createdBy: '', updatedBy: ''
+    };
+    (service.consultarNadaConsta as jest.Mock).mockReturnValueOnce(of(mockNadaConsta));
+    component.id = 2;
+    component.consultar();
+    tick();
+    expect(component.liveRegionText).toContain('Consulta concluída. Registro ID 2');
+    expect(component.liveRegionText).toContain('usuário Outro');
+    expect(component.liveRegionText).toContain('status PENDENTE');
+  }));
+
+  it('deve cancelar consulta anterior ao destruir', fakeAsync(() => {
+    const spy = jest.spyOn((component as any).destroyed$, 'next');
+    const spyComplete = jest.spyOn((component as any).destroyed$, 'complete');
+    component.id = 3;
+    (service.consultarNadaConsta as jest.Mock).mockReturnValueOnce(of({
+      id: 3,
+      usuario: { id: 3, nome: 'Cancelado', username: 'cancelado', documento: '', email: '', telefone: '', permissoes: [], fotoUrl: null, codigoVerificacao: '', ativo: true, authorities: [], accountNonExpired: true, accountNonLocked: true, credentialsNonExpired: true, enabled: true },
+      status: 'PENDENTE', sendAt: '', createdAt: '', updatedAt: '', createdBy: '', updatedBy: ''
+    }));
+    component.consultar();
+    component.ngOnDestroy();
+    expect(spy).toHaveBeenCalled();
+    expect(spyComplete).toHaveBeenCalled();
+  }));
+
   it('deve completar destroyed$ no ngOnDestroy', () => {
     const spy = jest.spyOn((component as any).destroyed$, 'next');
     const spyComplete = jest.spyOn((component as any).destroyed$, 'complete');

--- a/src/app/nada-consta/nada-consta.service.spec.ts
+++ b/src/app/nada-consta/nada-consta.service.spec.ts
@@ -91,5 +91,100 @@ describe('NadaConstaService', () => {
     const req = httpMock.expectOne(r => r.url.includes('/nadaconsta/solicitar'));
     req.flush('Bad request', {status: 400, statusText: 'Bad Request'});
   });
-});
 
+  it('deve verificar pendências do nada consta', () => {
+    const id = 42;
+    const mockResponse: NadaConsta = {
+      id,
+      usuario: {
+        id: 1,
+        nome: 'Teste',
+        username: 'teste',
+        documento: '123',
+        email: 'teste@teste.com',
+        telefone: '999',
+        permissoes: [],
+        fotoUrl: null,
+        codigoVerificacao: '',
+        ativo: true,
+        authorities: [],
+        accountNonExpired: true,
+        accountNonLocked: true,
+        credentialsNonExpired: true,
+        enabled: true
+      },
+      status: 'PENDENTE',
+      sendAt: '2025-10-21',
+      createdAt: '2025-10-21',
+      updatedAt: '2025-10-21',
+      createdBy: 'admin',
+      updatedBy: 'admin'
+    };
+    service.verificarPendencias(id).subscribe(resp => {
+      expect(resp).toEqual(mockResponse);
+    });
+    const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/verificar-pendencias/${id}`));
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({});
+    req.flush(mockResponse);
+  });
+
+  it('deve tratar erro ao verificar pendências', () => {
+    service.verificarPendencias(999).subscribe({
+      next: () => fail('Deveria falhar'),
+      error: err => {
+        expect(err.status).toBe(404);
+      }
+    });
+    const req = httpMock.expectOne(r => r.url.includes('/nadaconsta/verificar-pendencias/999'));
+    req.flush('Not found', {status: 404, statusText: 'Not Found'});
+  });
+
+  it('deve invalidar nada consta', () => {
+    const id = 42;
+    const mockResponse: NadaConsta = {
+      id,
+      usuario: {
+        id: 1,
+        nome: 'Teste',
+        username: 'teste',
+        documento: '123',
+        email: 'teste@teste.com',
+        telefone: '999',
+        permissoes: [],
+        fotoUrl: null,
+        codigoVerificacao: '',
+        ativo: true,
+        authorities: [],
+        accountNonExpired: true,
+        accountNonLocked: true,
+        credentialsNonExpired: true,
+        enabled: true
+      },
+      status: 'INVALIDADO',
+      sendAt: '2025-10-21',
+      createdAt: '2025-10-21',
+      updatedAt: '2025-10-21',
+      createdBy: 'admin',
+      updatedBy: 'admin'
+    };
+    service.invalidar(id).subscribe(resp => {
+      expect(resp).toEqual(mockResponse);
+    });
+    const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/invalidar/${id}`));
+    expect(req.request.method).toBe('PUT');
+    expect(req.request.body).toEqual({});
+    req.flush(mockResponse);
+  });
+
+  it('deve tratar erro ao invalidar nada consta', () => {
+    service.invalidar(999).subscribe({
+      next: () => fail('Deveria falhar'),
+      error: err => {
+        expect(err.status).toBe(404);
+      }
+    });
+    const req = httpMock.expectOne(r => r.url.includes('/nadaconsta/invalidar/999'));
+    req.flush('Not found', {status: 404, statusText: 'Not Found'});
+  });
+});

--- a/src/app/nada-consta/nada-consta.service.ts
+++ b/src/app/nada-consta/nada-consta.service.ts
@@ -40,18 +40,46 @@ export class NadaConstaService extends CrudService<NadaConsta, number> {
     super(`${environment.api_url}nadaconsta/`, http);
   }
 
+  /**
+   * Consulta um Nada Consta pelo id.
+   * @param {number} id Identificador do registro
+   * @returns {Observable<NadaConsta>} Observable do resultado da requisição
+   * @example
+   * this.nadaConstaService.consultarNadaConsta(123).subscribe(...)
+   */
   consultarNadaConsta(id: number) {
     return this.http.get<NadaConsta>(`${this.url}${id}`);
   }
 
+  /**
+   * Solicita um Nada Consta pelo documento.
+   * @param {string} documento Documento do usuário
+   * @returns {Observable<any>} Observable do resultado da requisição
+   * @example
+   * this.nadaConstaService.solicitar('12345678900').subscribe(...)
+   */
   solicitar(documento: string) {
     return this.http.post(`${this.url}solicitar`, { documento });
   }
 
+  /**
+   * Verifica pendências do Nada Consta pelo id.
+   * @param {number} id Identificador do registro
+   * @returns {Observable<NadaConsta>} Observable do resultado da requisição
+   * @example
+   * this.nadaConstaService.verificarPendencias(123).subscribe(...)
+   */
   verificarPendencias(id: number) {
     return this.http.put<NadaConsta>(`${this.url}verificar-pendencias/${id}`, {});
   }
 
+  /**
+   * Invalida o Nada Consta pelo id.
+   * @param {number} id Identificador do registro
+   * @returns {Observable<NadaConsta>} Observable do resultado da requisição
+   * @example
+   * this.nadaConstaService.invalidar(123).subscribe(...)
+   */
   invalidar(id: number) {
     return this.http.put<NadaConsta>(`${this.url}invalidar/${id}`, {});
   }

--- a/src/app/nada-consta/nada-consta.service.ts
+++ b/src/app/nada-consta/nada-consta.service.ts
@@ -47,4 +47,12 @@ export class NadaConstaService extends CrudService<NadaConsta, number> {
   solicitar(documento: string) {
     return this.http.post(`${this.url}solicitar`, { documento });
   }
+
+  verificarPendencias(id: number) {
+    return this.http.put<NadaConsta>(`${this.url}verificar-pendencias/${id}`, {});
+  }
+
+  invalidar(id: number) {
+    return this.http.put<NadaConsta>(`${this.url}invalidar/${id}`, {});
+  }
 }


### PR DESCRIPTION
This pull request introduces an endpoint for verifying and invalidating "nada consta" records. Additionally, updates to the UI have been implemented to support this feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Botão para verificar pendências com indicador de carregamento.
  * Botão para invalidar registros com diálogo de confirmação e confirmação/ cancelamento.
  * Melhorada acessibilidade com atributos ARIA em ações.
  * Indicadores visuais de carregamento ajustados.

* **Correções**
  * Ajuste na exibição de status: “INVALIDADO” agora tratado como status distinto e classificado como perigo; entradas sem status seguem o comportamento padrão.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->