### PR TITLE
Implement input masks for CNPJ and telefone fields

### DIFF
--- a/src/app/fornecedor/fornecedor.form.component.html
+++ b/src/app/fornecedor/fornecedor.form.component.html
@@ -70,15 +70,14 @@
                 [required]="true"
                 fieldId="cnpj"
                 hint="Digite apenas números (14 dígitos)">
-                <input
-                  pInputText
+                <p-input-mask
                   id="cnpj"
                   formControlName="cnpj"
-                  onlyNumber
-                  formatCnpj
-                  maxlength="14"
+                  mask="99.999.999/9999-99"
                   class="w-full"
-                  placeholder="00000000000000" />
+                  placeholder="00.000.000/0000-00"
+                  aria-label="CNPJ">
+                </p-input-mask>
               </app-form-field>
             </div>
 
@@ -106,14 +105,14 @@
                 [required]="true"
                 fieldId="telefone"
                 hint="Digite o telefone com DDD">
-                <input
-                  pInputText
+                <p-input-mask
                   id="telefone"
                   formControlName="telefone"
-                  formatTelefone
-                  maxlength="15"
+                  mask="(99) 99999-9999"
                   class="w-full"
-                  placeholder="(00) 00000-0000" />
+                  placeholder="(00) 00000-0000"
+                  aria-label="Telefone">
+                </p-input-mask>
               </app-form-field>
             </div>
 

--- a/src/app/fornecedor/fornecedor.form.component.html
+++ b/src/app/fornecedor/fornecedor.form.component.html
@@ -69,11 +69,12 @@
                 label="CNPJ"
                 [required]="true"
                 fieldId="cnpj"
-                hint="Digite apenas números (14 dígitos)">
+                hint="Digite no formato 00.000.000/0000-00">
                 <p-input-mask
                   id="cnpj"
                   formControlName="cnpj"
                   mask="99.999.999/9999-99"
+                  [unmask]="true"
                   class="w-full"
                   placeholder="00.000.000/0000-00"
                   aria-label="CNPJ">
@@ -108,9 +109,10 @@
                 <p-input-mask
                   id="telefone"
                   formControlName="telefone"
-                  mask="(99) 99999-9999"
+                  mask="(99) 9999?9-9999"
+                  [unmask]="true"
                   class="w-full"
-                  placeholder="(00) 00000-0000"
+                  placeholder="(00) 00000-0000 ou (00) 0000-0000"
                   aria-label="Telefone">
                 </p-input-mask>
               </app-form-field>

--- a/src/app/fornecedor/fornecedor.form.component.ts
+++ b/src/app/fornecedor/fornecedor.form.component.ts
@@ -80,7 +80,7 @@ export class FornecedorFormComponent extends PrimeReactiveCrudFormComponent<Forn
       ie: ['', [Validators.required, Validators.maxLength(50)]],
       endereco: ['', [Validators.required, Validators.maxLength(500)]],
       observacao: ['', [Validators.maxLength(2000)]],
-      telefone: ['', [Validators.required, Validators.minLength(11), Validators.maxLength(11)]],
+      telefone: ['', [Validators.required, Validators.pattern(/^\d{10,11}$/)]],
       email: ['', [Validators.required, Validators.email, Validators.maxLength(255)]],
       estado: [null, [Validators.required]],
       cidade: [null, [Validators.required]]

--- a/src/app/fornecedor/fornecedor.form.component.ts
+++ b/src/app/fornecedor/fornecedor.form.component.ts
@@ -18,6 +18,7 @@ import {TextareaModule} from 'primeng/textarea';
 import {AutoCompleteCompleteEvent, AutoCompleteModule} from 'primeng/autocomplete';
 import {ButtonModule} from 'primeng/button';
 import {TooltipModule} from 'primeng/tooltip';
+import {InputMaskModule} from 'primeng/inputmask';
 
 // Custom components
 import {FormFieldComponent} from '../framework/component/form-field.component';
@@ -41,6 +42,7 @@ import {LoggerService} from '../framework/services/logger.service';
     AutoCompleteModule,
     ButtonModule,
     TooltipModule,
+    InputMaskModule,
     // Custom
     FormFieldComponent,
     VoltarComponent,

--- a/src/app/fornecedor/fornecedor.form.component.ts
+++ b/src/app/fornecedor/fornecedor.form.component.ts
@@ -80,7 +80,7 @@ export class FornecedorFormComponent extends PrimeReactiveCrudFormComponent<Forn
       ie: ['', [Validators.required, Validators.maxLength(50)]],
       endereco: ['', [Validators.required, Validators.maxLength(500)]],
       observacao: ['', [Validators.maxLength(2000)]],
-      telefone: ['', [Validators.required, Validators.maxLength(15)]],
+      telefone: ['', [Validators.required, Validators.minLength(11), Validators.maxLength(11)]],
       email: ['', [Validators.required, Validators.email, Validators.maxLength(255)]],
       estado: [null, [Validators.required]],
       cidade: [null, [Validators.required]]


### PR DESCRIPTION
### Description

This pull request introduces input masks for the `CNPJ` and `telefone` fields in the `fornecedor` form to ensure proper formatting and usability.

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [ ] I have tested these changes manually.
- [ ] I have added tests that verify the change (if applicable).
- [ ] I have updated the documentation (if applicable). 

### Additional context

_No additional context provided._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Melhorias**
  * Máscaras de entrada para CNPJ ("00.000.000/0000-00") e Telefone ("(00) 00000-0000 ou (00) 0000-0000") no formulário de fornecedor, com unmask e placeholders atualizados.
  * Hints atualizados para orientar o formato de entrada.
  * Acessibilidade aprimorada: aria-labels adicionados aos campos.
  * Validação do telefone reforçada para aceitar apenas números com 10 ou 11 dígitos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->