### PR TITLE
Clear city field and enforce validation on state change in form

### DIFF
--- a/src/app/fornecedor/fornecedor.form.component.html
+++ b/src/app/fornecedor/fornecedor.form.component.html
@@ -170,7 +170,7 @@
                   [minQueryLength]="2"
                   [suggestions]="estadoList()"
                   (completeMethod)="findEstados($event)"
-                  (onChange)="onEstadoChange()"
+                  (onSelect)="onEstadoChange()"
                   styleClass="w-full"
                   [inputStyleClass]="'w-full'"
                   placeholder="Digite para buscar...">

--- a/src/app/fornecedor/fornecedor.form.component.ts
+++ b/src/app/fornecedor/fornecedor.form.component.ts
@@ -122,13 +122,20 @@ export class FornecedorFormComponent extends PrimeReactiveCrudFormComponent<Forn
   }
 
   /**
-   * Handle state change - clear city when state changes
+   * Handle state change - clear city when state changes and force required validation
    */
   onEstadoChange(): void {
     const formGroup = this.form();
     if (formGroup) {
+      // Limpa o campo cidade
       formGroup.patchValue({ cidade: null });
+      // Limpa lista de cidades
       this.cidadeList.set([]);
+      // Reaplica o validador required (caso removido por algum fluxo)
+      formGroup.get('cidade')?.setValidators([Validators.required]);
+      formGroup.get('cidade')?.updateValueAndValidity();
+      // Marca como touched para exibir erro imediatamente
+      formGroup.get('cidade')?.markAsTouched();
     }
   }
 


### PR DESCRIPTION
This pull request introduces a feature to automatically clear the city field and apply validation when the state field is updated in the fornecedor form. This ensures data integrity and enhances user input handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Melhorado o comportamento do seletor de Estado no formulário de fornecedor para responder apenas a seleções efetivas.
  * Validação do campo Cidade agora é acionada corretamente ao trocar de Estado, com mensagens de erro exibidas de forma imediata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->