### PR TITLE
Add action buttons for edit and delete in empréstimos list

### DIFF
--- a/src/app/emprestimo/emprestimo.list.component.html
+++ b/src/app/emprestimo/emprestimo.list.component.html
@@ -167,6 +167,18 @@
                         }
                       </div>
                     }
+                    @case ('actions') {
+                      <app-action-buttons
+                        [showEdit]="canEdit()"
+                        [showDelete]="canDelete()"
+                        [editTooltip]="'Editar empréstimo'"
+                        [deleteTooltip]="'Remover empréstimo'"
+                        [editAriaLabel]="'Editar empréstimo ' + row.id"
+                        [deleteAriaLabel]="'Remover empréstimo ' + row.id"
+                        (edit)="edit(row.id)"
+                        (delete)="delete(row.id)">
+                      </app-action-buttons>
+                    }
                     @default {
                       <span [attr.aria-label]="column.header + ': ' + row[column.field]">
                         {{ row[column.field] }}

--- a/src/app/emprestimo/emprestimo.list.component.spec.ts
+++ b/src/app/emprestimo/emprestimo.list.component.spec.ts
@@ -110,7 +110,8 @@ describe('EmprestimoListComponent', () => {
         'usuarioEmprestimo',
         'dataEmprestimo',
         'prazoDevolucao',
-        'status'
+        'status',
+        'actions'
       ]);
     });
 
@@ -612,7 +613,7 @@ describe('EmprestimoListComponent', () => {
 
     it('deve configurar tabela corretamente', () => {
       expect(component['tableConfig'].columns).toBeDefined();
-      expect(component['tableConfig'].columns.length).toBe(5);
+      expect(component['tableConfig'].columns.length).toBe(6);
       expect(component['tableConfig'].defaultSortField).toBe('id');
     });
 

--- a/src/app/emprestimo/emprestimo.list.component.ts
+++ b/src/app/emprestimo/emprestimo.list.component.ts
@@ -47,6 +47,8 @@ export class EmprestimoListComponent extends PrimeCrudListComponent<Emprestimo, 
   contextMenuItems: MenuItem[] = [];
   protected override service = inject(EmprestimoService);
   protected readonly breakpointService = inject(BreakpointService);
+  protected override urlForm = 'emprestimo/form';
+  private readonly usuarioService = inject(UsuarioService);
 
   // Constants for template
   protected readonly Z_INDEX = Z_INDEX;
@@ -58,9 +60,7 @@ export class EmprestimoListComponent extends PrimeCrudListComponent<Emprestimo, 
   usuarioResponsavel: Usuario[] = [];
   dtNovaData!: string;
   idEmprestimoToChangePrazoDev!: number;
-  protected override columnsTable = ['id', 'usuarioEmprestimo', 'dataEmprestimo', 'prazoDevolucao', 'status'];
-  protected override urlForm = 'emprestimo/form';
-  private readonly usuarioService = inject(UsuarioService);
+  protected override columnsTable = ['id', 'usuarioEmprestimo', 'dataEmprestimo', 'prazoDevolucao', 'status', 'actions'];
   private readonly tableColumns: TableColumn[] = [
     {
       field: 'id',
@@ -105,6 +105,17 @@ export class EmprestimoListComponent extends PrimeCrudListComponent<Emprestimo, 
       filterable: false,
       width: '10rem',
       align: 'center'
+    },
+    {
+      field: 'actions',
+      header: 'Ações',
+      type: 'custom',
+      sortable: false,
+      filterable: false,
+      exportable: false,
+      align: 'center',
+      width: '10rem',
+      toggleable: false
     }
   ];
 
@@ -167,20 +178,16 @@ export class EmprestimoListComponent extends PrimeCrudListComponent<Emprestimo, 
   findUsuarios($event: { query: string }) {
     this.usuarioService.completeCustom($event.query)
     .subscribe({
-      next: (usuarios) => {
+      next: (usuarios: Usuario[]) => {
         this.usuarioEmprestimoList = usuarios;
       }
     });
   }
 
-  protected override getExportFileName(): string {
-    return 'emprestimos';
-  }
-
   findUsuarioResponsavel($event: { query: string }) {
     this.usuarioService.completeCustomUsersLab($event.query)
     .subscribe({
-      next: (usuarios) => {
+      next: (usuarios: Usuario[]) => {
         this.usuarioResponsavel = usuarios;
       }
     });

--- a/src/app/emprestimo/emprestimo.list.component.ts
+++ b/src/app/emprestimo/emprestimo.list.component.ts
@@ -323,6 +323,10 @@ export class EmprestimoListComponent extends PrimeCrudListComponent<Emprestimo, 
     return 'Empréstimos';
   }
 
+  protected override getExportFileName(): string {
+    return 'emprestimos';
+  }
+
   private configureTable(): void {
     this.tableConfig = createTableConfig({
       columns: this.tableColumns,


### PR DESCRIPTION
This pull request introduces action buttons to the empréstimos list feature, allowing users to edit and delete records directly from the list view.

### Summary of Changes
- Added action buttons for editing and deleting records in the empréstimos list.

### Checklist
- [ ] Code builds and runs locally.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated if applicable. 

### Testing Instructions
1. Access the empréstimos list view.
2. Verify the presence of new action buttons for edit and delete.
3. Test the edit and delete actions to ensure they work as expected.