### PR TITLE
Feature/fix qtde minima atualizada apos editar patrimonio

### DIFF
--- a/src/app/item/item.form.component.html
+++ b/src/app/item/item.form.component.html
@@ -67,7 +67,6 @@
                   formControlName="patrimonio"
                   class="w-full"
                   [useGrouping]="false"
-                  (onInput)="onPatrimonioChange()"
                   styleClass="w-full">
                 </p-inputNumber>
               </app-form-field>

--- a/src/app/item/item.form.component.spec.ts
+++ b/src/app/item/item.form.component.spec.ts
@@ -189,13 +189,13 @@ describe('ItemFormComponent', () => {
       expect(formGroup?.get('qtdeMinima')?.value).toBe(1);
     });
 
-    it('should set saldo to 1 when patrimonio is filled', () => {
+    it('should not automatically set saldo when patrimonio is filled', () => {
       const formGroup = component['form']();
-      formGroup?.patchValue({patrimonio: 'PAT123'});
-      component.onPatrimonioChange();
+      formGroup?.patchValue({patrimonio: 'PAT123', saldo: 5, qtdeMinima: 3});
 
-      expect(formGroup?.get('saldo')?.value).toBe(1);
-      expect(formGroup?.get('qtdeMinima')?.value).toBe(1);
+      // Patrimonio change should not reset saldo/qtdeMinima
+      expect(formGroup?.get('saldo')?.value).toBe(5);
+      expect(formGroup?.get('qtdeMinima')?.value).toBe(3);
     });
   });
 
@@ -419,12 +419,12 @@ describe('ItemFormComponent', () => {
   describe('Form Permissions - Aluno/Professor', () => {
     it('should set isAlunoOrProfessor signal based on login service', async () => {
       loginService.userLoggedIsAlunoOrProfessor.mockResolvedValue(true);
-      
+
       await component.ngOnInit();
-      
+
       // Wait for all async operations to complete
       await fixture.whenStable();
-      
+
       expect(loginService.userLoggedIsAlunoOrProfessor).toHaveBeenCalled();
     });
 
@@ -433,7 +433,7 @@ describe('ItemFormComponent', () => {
       fixture.detectChanges();
 
       const formGroup = component['form']();
-      
+
       // These fields should always be disabled
       expect(formGroup?.get('disponivelEmprestimoCalculado')?.disabled).toBeTruthy();
       expect(formGroup?.get('quantidadeEmprestada')?.disabled).toBeTruthy();
@@ -502,17 +502,8 @@ describe('ItemFormComponent', () => {
     it('should call updatePatrimonioValidators when onTipoItemChange is called', () => {
       component.ngOnInit();
       const spy = jest.spyOn(component as any, 'updatePatrimonioValidators');
-      
+
       component.onTipoItemChange();
-
-      expect(spy).toHaveBeenCalled();
-    });
-
-    it('should call setSaldoDefaultItem when onPatrimonioChange is called', () => {
-      component.ngOnInit();
-      const spy = jest.spyOn(component as any, 'setSaldoDefaultItem');
-      
-      component.onPatrimonioChange();
 
       expect(spy).toHaveBeenCalled();
     });

--- a/src/app/item/item.form.component.ts
+++ b/src/app/item/item.form.component.ts
@@ -446,12 +446,7 @@ export class ItemFormComponent extends PrimeReactiveCrudFormComponent<Item, numb
     this.setSaldoDefaultItem();
   }
 
-  /**
-   * Handle patrimonio change
-   */
-  onPatrimonioChange(): void {
-    this.setSaldoDefaultItem();
-  }
+
 
   /**
    * Update patrimonio validators based on tipoItem


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Alterações

* **Bug Fixes**
  * Corrigido o comportamento automático do campo Patrimônio que reiniciava desnecessariamente os valores dos campos Saldo e Quantidade Mínima. Esses campos agora preservam suas configurações anteriores quando o Patrimônio é editado, proporcionando maior controle e flexibilidade na edição de itens sem perder dados já configurados.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->