### PR TITLE
Implement PDF download and email resend features

### DIFF
--- a/src/app/nada-consta/list/nada-consta-list.component.html
+++ b/src/app/nada-consta/list/nada-consta-list.component.html
@@ -147,7 +147,11 @@
                 [style.width]="column.width"
                 [style.min-width]="column.minWidth"
                 [attr.headers]="'col-' + column.field"
+                [attr.role]="column.field !== 'acoes' ? 'button' : null"
+                [attr.tabindex]="column.field !== 'acoes' ? '0' : null"
                 (click)="column.field !== 'acoes' ? openOptions($event, row.id) : null"
+                (keydown.enter)="column.field !== 'acoes' ? openOptions($event, row.id) : null"
+                (keydown.space)="column.field !== 'acoes' && $event.preventDefault(); column.field !== 'acoes' ? openOptions($event, row.id) : null"
                 [class.cursor-pointer]="column.field !== 'acoes'">
                 @switch (column.field) {
                   @case ('status') {

--- a/src/app/nada-consta/list/nada-consta-list.component.html
+++ b/src/app/nada-consta/list/nada-consta-list.component.html
@@ -147,19 +147,44 @@
                 [style.width]="column.width"
                 [style.min-width]="column.minWidth"
                 [attr.headers]="'col-' + column.field"
-                class="cursor-pointer">
+                (click)="column.field !== 'acoes' ? openOptions($event, row.id) : null"
+                [class.cursor-pointer]="column.field !== 'acoes'">
                 @switch (column.field) {
                   @case ('status') {
                     <p-tag [value]="getStatusLabel(row.status)" [severity]="getStatusSeverity(row.status)"></p-tag>
                   }
                   @case ('acoes') {
                     <div class="flex justify-center gap-2">
-                      @if (row.status === 'completed') {
-                        <p-button icon="pi pi-print" class="p-button-text p-button-rounded" pTooltip="Imprimir Nada Consta" tooltipPosition="top" (onClick)="imprimirNadaConsta(row)" [attr.aria-label]="'Imprimir Nada Consta ' + row.id"></p-button>
-                        <p-button icon="pi pi-bars" class="p-button-text p-button-rounded" pTooltip="Ações" tooltipPosition="top" (click)="openOptions($event, row.id); $event.stopPropagation()" [attr.aria-label]="'Abrir menu de ações ' + row.id"></p-button>
-                      } @else if (row.status === 'pending') {
-                        <p-button icon="pi pi-refresh" class="p-button-text p-button-rounded" pTooltip="Revalidar" tooltipPosition="top" (onClick)="verificarPendencias(row)" [loading]="verificandoPendencias() === row.id" [attr.aria-label]="'Revalidar Nada Consta ' + row.id"></p-button>
-                        <p-button icon="pi pi-bars" class="p-button-text p-button-rounded" pTooltip="Ações" tooltipPosition="top" (click)="openOptions($event, row.id); $event.stopPropagation()" [attr.aria-label]="'Abrir menu de ações ' + row.id"></p-button>
+                      @if (row.status?.toUpperCase() === 'COMPLETED' || row.status?.toUpperCase() === 'CONCLUIDO' || row.status?.toUpperCase() === 'CONCLUÍDO') {
+                        <p-button
+                          icon="pi pi-print"
+                          [text]="true"
+                          [rounded]="true"
+                          pTooltip="Imprimir Nada Consta"
+                          tooltipPosition="top"
+                          (onClick)="imprimirNadaConsta(row); $event.stopPropagation()"
+                          [attr.aria-label]="'Imprimir Nada Consta ' + row.id">
+                        </p-button>
+                        <p-button
+                          icon="pi pi-ellipsis-v"
+                          [text]="true"
+                          [rounded]="true"
+                          pTooltip="Menu de ações"
+                          tooltipPosition="top"
+                          (onClick)="openOptions($event, row.id); $event.stopPropagation()"
+                          [attr.aria-label]="'Abrir menu de ações ' + row.id">
+                        </p-button>
+                      } @else if (row.status?.toUpperCase() === 'PENDING' || row.status?.toUpperCase() === 'PENDENTE') {
+                        <p-button
+                          icon="pi pi-refresh"
+                          [text]="true"
+                          [rounded]="true"
+                          pTooltip="Revalidar"
+                          tooltipPosition="top"
+                          (onClick)="verificarPendencias(row); $event.stopPropagation()"
+                          [loading]="verificandoPendencias() === row.id"
+                          [attr.aria-label]="'Revalidar Nada Consta ' + row.id">
+                        </p-button>
                       }
                       <!-- status invalidated: não mostra nada -->
                     </div>

--- a/src/app/nada-consta/list/nada-consta-list.component.html
+++ b/src/app/nada-consta/list/nada-consta-list.component.html
@@ -146,37 +146,22 @@
                 [style.text-align]="column.align || 'left'"
                 [style.width]="column.width"
                 [style.min-width]="column.minWidth"
-                [attr.headers]="'col-' + column.field">
+                [attr.headers]="'col-' + column.field"
+                class="cursor-pointer">
                 @switch (column.field) {
                   @case ('status') {
                     <p-tag [value]="getStatusLabel(row.status)" [severity]="getStatusSeverity(row.status)"></p-tag>
                   }
                   @case ('acoes') {
-                    <div class="flex justify-between gap-2">
-                      @switch (getStatusLabel(row.status)) {
-                        @case ('COM PENDÊNCIA') {
-                          <p-button
-                            icon="pi pi-refresh"
-                            class="p-button-text p-button-rounded"
-                            pTooltip="Verificar Pendências"
-                            tooltipPosition="top"
-                            [loading]="verificandoPendencias() === row.id"
-                            (onClick)="verificarPendencias(row)"
-                            [attr.aria-label]="'Verificar pendências do registro ' + row.id"
-                          ></p-button>
-                        }
-                        @case ('EMITIDO') {
-                          <p-button
-                            icon="pi pi-ban"
-                            class="p-button-text p-button-rounded"
-                            pTooltip="Invalidar Nada Consta"
-                            tooltipPosition="top"
-                            [loading]="invalidando() === row.id"
-                            (onClick)="abrirDialogConfirmarInvalidar(row)"
-                            [attr.aria-label]="'Invalidar registro ' + row.id"
-                          ></p-button>
-                        }
+                    <div class="flex justify-center gap-2">
+                      @if (row.status === 'completed') {
+                        <p-button icon="pi pi-print" class="p-button-text p-button-rounded" pTooltip="Imprimir Nada Consta" tooltipPosition="top" (onClick)="imprimirNadaConsta(row)" [attr.aria-label]="'Imprimir Nada Consta ' + row.id"></p-button>
+                        <p-button icon="pi pi-bars" class="p-button-text p-button-rounded" pTooltip="Ações" tooltipPosition="top" (click)="openOptions($event, row.id); $event.stopPropagation()" [attr.aria-label]="'Abrir menu de ações ' + row.id"></p-button>
+                      } @else if (row.status === 'pending') {
+                        <p-button icon="pi pi-refresh" class="p-button-text p-button-rounded" pTooltip="Revalidar" tooltipPosition="top" (onClick)="verificarPendencias(row)" [loading]="verificandoPendencias() === row.id" [attr.aria-label]="'Revalidar Nada Consta ' + row.id"></p-button>
+                        <p-button icon="pi pi-bars" class="p-button-text p-button-rounded" pTooltip="Ações" tooltipPosition="top" (click)="openOptions($event, row.id); $event.stopPropagation()" [attr.aria-label]="'Abrir menu de ações ' + row.id"></p-button>
                       }
+                      <!-- status invalidated: não mostra nada -->
                     </div>
                   }
                   @case ('usuarioUsername') {
@@ -210,6 +195,11 @@
           </app-table-empty-state>
         </ng-template>
       </p-table>
+
+      <!-- Popover global, fora do loop -->
+      <p-popover #actionsMenu>
+        <p-menu [model]="contextMenuItems" [style]="{border: 'none'}"></p-menu>
+      </p-popover>
     </ng-template>
   </p-card>
 </div>

--- a/src/app/nada-consta/list/nada-consta-list.component.html
+++ b/src/app/nada-consta/list/nada-consta-list.component.html
@@ -226,7 +226,7 @@
       </p-table>
 
       <!-- Popover global, fora do loop -->
-      <p-popover #actionsMenu>
+      <p-popover #actionsMenu [attr.aria-label]="'Menu de ações do Nada Consta'">
         <p-menu [model]="contextMenuItems" [style]="{border: 'none'}"></p-menu>
       </p-popover>
     </ng-template>

--- a/src/app/nada-consta/list/nada-consta-list.component.spec.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.spec.ts
@@ -13,18 +13,25 @@ describe('NadaConstaListComponent', () => {
   let component: NadaConstaListComponent;
   let service: NadaConstaService;
 
+  let messageService: MessageService;
+
   beforeEach(async () => {
     const serviceMock = {
       solicitar: jest.fn(),
       findAll: jest.fn().mockReturnValue(of([])),
       findAllPaged: jest.fn().mockReturnValue(of([])),
       verificarPendencias: jest.fn(),
-      invalidar: jest.fn()
+      invalidar: jest.fn(),
+      downloadPdf: jest.fn(),
+      reenviarEmail: jest.fn()
+    };
+    const messageServiceMock = {
+      add: jest.fn()
     };
     await TestBed.configureTestingModule({
       providers: [
         { provide: NadaConstaService, useValue: serviceMock },
-        { provide: MessageService, useValue: {} },
+        { provide: MessageService, useValue: messageServiceMock },
         { provide: ConfirmationService, useValue: {} },
         { provide: LoaderService, useValue: {} },
         { provide: LoginService, useValue: {} },
@@ -35,6 +42,7 @@ describe('NadaConstaListComponent', () => {
     fixture = TestBed.createComponent(NadaConstaListComponent);
     component = fixture.componentInstance;
     service = TestBed.inject(NadaConstaService);
+    messageService = TestBed.inject(MessageService);
   });
 
   it('deve ser criado', () => {
@@ -117,7 +125,11 @@ describe('NadaConstaListComponent', () => {
     component.verificarPendencias(row);
     tick();
     expect(component.getVerificandoPendencias()).toBeNull();
-    expect(component.getAcaoSucesso()).toBe('Pendências verificadas com sucesso.');
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Sucesso',
+      detail: 'Pendências verificadas com sucesso.'
+    });
     expect(findAllSpy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalled();
   }));
@@ -129,7 +141,11 @@ describe('NadaConstaListComponent', () => {
     component.verificarPendencias(row);
     tick();
     expect(component.getVerificandoPendencias()).toBeNull();
-    expect(component.getAcaoErro()).toBe('Erro ao verificar');
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Erro',
+      detail: 'Erro ao verificar'
+    });
     expect(spy).toHaveBeenCalled();
   }));
 
@@ -141,7 +157,11 @@ describe('NadaConstaListComponent', () => {
     component.invalidar(row);
     tick();
     expect(component.getInvalidando()).toBeNull();
-    expect(component.getAcaoSucesso()).toBe('Nada Consta invalidado com sucesso.');
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Sucesso',
+      detail: 'Nada Consta invalidado com sucesso.'
+    });
     expect(findAllSpy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalled();
   }));
@@ -153,7 +173,11 @@ describe('NadaConstaListComponent', () => {
     component.invalidar(row);
     tick();
     expect(component.getInvalidando()).toBeNull();
-    expect(component.getAcaoErro()).toBe('Erro ao invalidar');
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Erro',
+      detail: 'Erro ao invalidar'
+    });
     expect(spy).toHaveBeenCalled();
   }));
 
@@ -190,14 +214,304 @@ describe('NadaConstaListComponent', () => {
     expect(hideInvalidar).toBe(false);
   });
 
-  it('deve controlar sinais de loading e feedback', () => {
+  it('deve controlar sinais de loading', () => {
     component.setVerificandoPendencias(10);
     expect(component.getVerificandoPendencias()).toBe(10);
     component.setInvalidando(20);
     expect(component.getInvalidando()).toBe(20);
-    component.setAcaoErro('erro');
-    expect(component.getAcaoErro()).toBe('erro');
-    component.setAcaoSucesso('sucesso');
-    expect(component.getAcaoSucesso()).toBe('sucesso');
+  });
+
+  describe('imprimirNadaConsta', () => {
+    it('deve baixar e abrir PDF com sucesso', fakeAsync(() => {
+      const mockArrayBuffer = new ArrayBuffer(8);
+      (service.downloadPdf as jest.Mock).mockReturnValue(of(mockArrayBuffer));
+
+      // Mock window.URL methods
+      const mockBlobUrl = 'blob:mock-url';
+      const urlCreateSpy = jest.fn().mockReturnValue(mockBlobUrl);
+      const urlRevokeSpy = jest.fn();
+      Object.defineProperty(window.URL, 'createObjectURL', {
+        value: urlCreateSpy,
+        writable: true,
+        configurable: true
+      });
+      Object.defineProperty(window.URL, 'revokeObjectURL', {
+        value: urlRevokeSpy,
+        writable: true,
+        configurable: true
+      });
+
+      const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+      // Mock do actionsMenu
+      const actionsMenuMock = { hide: jest.fn(), toggle: jest.fn() };
+      Object.defineProperty(component, 'actionsMenu', {
+        value: () => actionsMenuMock,
+        writable: true
+      });
+
+      const row = { id: 11 } as any;
+      component.imprimirNadaConsta(row);
+      tick();
+
+      expect(actionsMenuMock.hide).toHaveBeenCalled();
+      expect(service.downloadPdf).toHaveBeenCalledWith(11);
+      expect(urlCreateSpy).toHaveBeenCalled();
+      expect(windowOpenSpy).toHaveBeenCalledWith(mockBlobUrl, '_blank');
+      expect(messageService.add).toHaveBeenCalledWith({
+        severity: 'success',
+        summary: 'PDF Gerado',
+        detail: 'O PDF foi aberto em uma nova aba.'
+      });
+
+      tick(100);
+      expect(urlRevokeSpy).toHaveBeenCalledWith(mockBlobUrl);
+
+      windowOpenSpy.mockRestore();
+    }));
+
+    it('deve tratar erro ao baixar PDF', fakeAsync(() => {
+      (service.downloadPdf as jest.Mock).mockReturnValue(throwError(() => ({ error: { message: 'Erro ao gerar PDF' } })));
+
+      const actionsMenuMock = { hide: jest.fn(), toggle: jest.fn() };
+      Object.defineProperty(component, 'actionsMenu', {
+        value: () => actionsMenuMock,
+        writable: true
+      });
+
+      const row = { id: 12 } as any;
+      component.imprimirNadaConsta(row);
+      tick();
+
+      expect(messageService.add).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Erro',
+        detail: 'Erro ao gerar PDF'
+      });
+    }));
+  });
+
+  describe('reenviarEmailNadaConsta', () => {
+    it('deve reenviar email com sucesso', fakeAsync(() => {
+      (service.reenviarEmail as jest.Mock).mockReturnValue(of({}));
+
+      const actionsMenuMock = { hide: jest.fn(), toggle: jest.fn() };
+      Object.defineProperty(component, 'actionsMenu', {
+        value: () => actionsMenuMock,
+        writable: true
+      });
+
+      const row = { id: 13 } as any;
+      component.reenviarEmailNadaConsta(row);
+      tick();
+
+      expect(actionsMenuMock.hide).toHaveBeenCalled();
+      expect(service.reenviarEmail).toHaveBeenCalledWith(13);
+      expect(messageService.add).toHaveBeenCalledWith({
+        severity: 'success',
+        summary: 'Email Enviado',
+        detail: '2ª via do Nada Consta enviada com sucesso.'
+      });
+    }));
+
+    it('deve tratar erro ao reenviar email', fakeAsync(() => {
+      (service.reenviarEmail as jest.Mock).mockReturnValue(throwError(() => ({ error: { message: 'Erro ao enviar email' } })));
+
+      const actionsMenuMock = { hide: jest.fn(), toggle: jest.fn() };
+      Object.defineProperty(component, 'actionsMenu', {
+        value: () => actionsMenuMock,
+        writable: true
+      });
+
+      const row = { id: 14 } as any;
+      component.reenviarEmailNadaConsta(row);
+      tick();
+
+      expect(messageService.add).toHaveBeenCalledWith({
+        severity: 'error',
+        summary: 'Erro',
+        detail: 'Erro ao enviar email'
+      });
+    }));
+  });
+
+  describe('openOptions - Menu por Status', () => {
+    let actionsMenuMock: any;
+
+    beforeEach(() => {
+      actionsMenuMock = { hide: jest.fn(), toggle: jest.fn() };
+      Object.defineProperty(component, 'actionsMenu', {
+        value: () => actionsMenuMock,
+        writable: true
+      });
+    });
+
+    it('deve abrir menu com opções completas para status COMPLETED', () => {
+      component.objects = [
+        { id: 15, status: 'COMPLETED', usuario: { nome: 'João' } } as any
+      ];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 15);
+
+      expect(component.contextMenuItems).toHaveLength(4);
+      expect(component.contextMenuItems[0].label).toBe('Imprimir');
+      expect(component.contextMenuItems[1].label).toBe('2ª via email');
+      expect(component.contextMenuItems[2].label).toBe('Invalidar');
+      expect(component.contextMenuItems[3].label).toBe('Cancelar');
+      expect(actionsMenuMock.toggle).toHaveBeenCalledWith(mockEvent);
+    });
+
+    it('deve abrir menu com opções completas para status CONCLUIDO (variante)', () => {
+      component.objects = [
+        { id: 16, status: 'CONCLUIDO', usuario: { nome: 'Maria' } } as any
+      ];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 16);
+
+      expect(component.contextMenuItems).toHaveLength(4);
+      expect(component.contextMenuItems[0].label).toBe('Imprimir');
+      expect(actionsMenuMock.toggle).toHaveBeenCalled();
+    });
+
+    it('deve abrir menu apenas com Revalidar para status PENDING', () => {
+      component.objects = [
+        { id: 17, status: 'PENDING', usuario: { nome: 'Pedro' } } as any
+      ];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 17);
+
+      expect(component.contextMenuItems).toHaveLength(2);
+      expect(component.contextMenuItems[0].label).toBe('Revalidar');
+      expect(component.contextMenuItems[1].label).toBe('Cancelar');
+      expect(actionsMenuMock.toggle).toHaveBeenCalled();
+    });
+
+    it('deve abrir menu apenas com Revalidar para status PENDENTE (variante)', () => {
+      component.objects = [
+        { id: 18, status: 'PENDENTE', usuario: { nome: 'Ana' } } as any
+      ];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 18);
+
+      expect(component.contextMenuItems).toHaveLength(2);
+      expect(component.contextMenuItems[0].label).toBe('Revalidar');
+      expect(actionsMenuMock.toggle).toHaveBeenCalled();
+    });
+
+    it('não deve abrir menu para status INVALIDATED', () => {
+      component.objects = [
+        { id: 19, status: 'INVALIDATED', usuario: { nome: 'Carlos' } } as any
+      ];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 19);
+
+      expect(component.contextMenuItems).toHaveLength(0);
+      expect(actionsMenuMock.toggle).not.toHaveBeenCalled();
+    });
+
+    it('não deve fazer nada se o registro não for encontrado', () => {
+      component.objects = [];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 999);
+
+      expect(component.contextMenuItems).toHaveLength(0);
+      expect(actionsMenuMock.toggle).not.toHaveBeenCalled();
+    });
+
+    it('deve executar comando Imprimir ao clicar', fakeAsync(() => {
+      const row = { id: 20, status: 'COMPLETED', usuario: { nome: 'José' } } as any;
+      component.objects = [row];
+      const imprimirSpy = jest.spyOn(component, 'imprimirNadaConsta').mockImplementation(() => {});
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 20);
+
+      const imprimirItem = component.contextMenuItems.find(item => item.label === 'Imprimir');
+      imprimirItem?.command?.({});
+      tick();
+
+      expect(imprimirSpy).toHaveBeenCalledWith(row);
+    }));
+
+    it('deve executar comando 2ª via email ao clicar', fakeAsync(() => {
+      const row = { id: 21, status: 'COMPLETED', usuario: { nome: 'Fernanda' } } as any;
+      component.objects = [row];
+      const reenviarSpy = jest.spyOn(component, 'reenviarEmailNadaConsta').mockImplementation(() => {});
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 21);
+
+      const reenviarItem = component.contextMenuItems.find(item => item.label === '2ª via email');
+      reenviarItem?.command?.({});
+      tick();
+
+      expect(reenviarSpy).toHaveBeenCalledWith(row);
+    }));
+
+    it('deve executar comando Invalidar e fechar menu ao clicar', fakeAsync(() => {
+      const row = { id: 22, status: 'COMPLETED', usuario: { nome: 'Lucas' } } as any;
+      component.objects = [row];
+      const invalidarSpy = jest.spyOn(component, 'abrirDialogConfirmarInvalidar').mockImplementation(() => {});
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 22);
+
+      const invalidarItem = component.contextMenuItems.find(item => item.label === 'Invalidar');
+      invalidarItem?.command?.({});
+      tick();
+
+      expect(actionsMenuMock.hide).toHaveBeenCalled();
+      expect(invalidarSpy).toHaveBeenCalledWith(row);
+    }));
+
+    it('deve executar comando Revalidar e fechar menu ao clicar', fakeAsync(() => {
+      const row = { id: 23, status: 'PENDING', usuario: { nome: 'Mariana' } } as any;
+      component.objects = [row];
+      const revalidarSpy = jest.spyOn(component, 'verificarPendencias').mockImplementation(() => {});
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 23);
+
+      const revalidarItem = component.contextMenuItems.find(item => item.label === 'Revalidar');
+      revalidarItem?.command?.({});
+      tick();
+
+      expect(actionsMenuMock.hide).toHaveBeenCalled();
+      expect(revalidarSpy).toHaveBeenCalledWith(row);
+    }));
+
+    it('deve fechar menu ao clicar em Cancelar', () => {
+      const row = { id: 24, status: 'COMPLETED', usuario: { nome: 'Rafael' } } as any;
+      component.objects = [row];
+
+      const mockEvent = new Event('click');
+      component.openOptions(mockEvent, 24);
+
+      const cancelarItem = component.contextMenuItems.find(item => item.label === 'Cancelar');
+      cancelarItem?.command?.({});
+
+      expect(actionsMenuMock.hide).toHaveBeenCalled();
+    });
+
+    it('deve normalizar status em lowercase para uppercase na comparação', () => {
+      component.objects = [
+        { id: 25, status: 'completed', usuario: { nome: 'Baixo' } } as any,
+        { id: 26, status: 'pending', usuario: { nome: 'Pendente' } } as any
+      ];
+
+      const mockEvent1 = new Event('click');
+      component.openOptions(mockEvent1, 25);
+      expect(component.contextMenuItems[0].label).toBe('Imprimir');
+
+      const mockEvent2 = new Event('click');
+      component.openOptions(mockEvent2, 26);
+      expect(component.contextMenuItems[0].label).toBe('Revalidar');
+    });
   });
 });

--- a/src/app/nada-consta/list/nada-consta-list.component.spec.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.spec.ts
@@ -226,22 +226,22 @@ describe('NadaConstaListComponent', () => {
       const mockArrayBuffer = new ArrayBuffer(8);
       (service.downloadPdf as jest.Mock).mockReturnValue(of(mockArrayBuffer));
 
-      // Mock window.URL methods
+      // Mock globalThis.URL methods
       const mockBlobUrl = 'blob:mock-url';
       const urlCreateSpy = jest.fn().mockReturnValue(mockBlobUrl);
       const urlRevokeSpy = jest.fn();
-      Object.defineProperty(window.URL, 'createObjectURL', {
+      Object.defineProperty(globalThis.URL, 'createObjectURL', {
         value: urlCreateSpy,
         writable: true,
         configurable: true
       });
-      Object.defineProperty(window.URL, 'revokeObjectURL', {
+      Object.defineProperty(globalThis.URL, 'revokeObjectURL', {
         value: urlRevokeSpy,
         writable: true,
         configurable: true
       });
 
-      const windowOpenSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+      const globalOpenSpy = jest.spyOn(globalThis, 'open').mockImplementation(() => null);
 
       // Mock do actionsMenu
       const actionsMenuMock = { hide: jest.fn(), toggle: jest.fn() };
@@ -257,7 +257,7 @@ describe('NadaConstaListComponent', () => {
       expect(actionsMenuMock.hide).toHaveBeenCalled();
       expect(service.downloadPdf).toHaveBeenCalledWith(11);
       expect(urlCreateSpy).toHaveBeenCalled();
-      expect(windowOpenSpy).toHaveBeenCalledWith(mockBlobUrl, '_blank');
+      expect(globalOpenSpy).toHaveBeenCalledWith(mockBlobUrl, '_blank');
       expect(messageService.add).toHaveBeenCalledWith({
         severity: 'success',
         summary: 'PDF Gerado',
@@ -267,7 +267,7 @@ describe('NadaConstaListComponent', () => {
       tick(100);
       expect(urlRevokeSpy).toHaveBeenCalledWith(mockBlobUrl);
 
-      windowOpenSpy.mockRestore();
+      globalOpenSpy.mockRestore();
     }));
 
     it('deve tratar erro ao baixar PDF', fakeAsync(() => {

--- a/src/app/nada-consta/list/nada-consta-list.component.spec.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.spec.ts
@@ -427,7 +427,7 @@ describe('NadaConstaListComponent', () => {
     it('deve executar comando Imprimir ao clicar', fakeAsync(() => {
       const row = { id: 20, status: 'COMPLETED', usuario: { nome: 'José' } } as any;
       component.objects = [row];
-      const imprimirSpy = jest.spyOn(component, 'imprimirNadaConsta').mockImplementation(() => {});
+      const imprimirSpy = jest.spyOn(component, 'imprimirNadaConsta').mockImplementation(() => undefined);
 
       const mockEvent = new Event('click');
       component.openOptions(mockEvent, 20);
@@ -442,7 +442,7 @@ describe('NadaConstaListComponent', () => {
     it('deve executar comando 2ª via email ao clicar', fakeAsync(() => {
       const row = { id: 21, status: 'COMPLETED', usuario: { nome: 'Fernanda' } } as any;
       component.objects = [row];
-      const reenviarSpy = jest.spyOn(component, 'reenviarEmailNadaConsta').mockImplementation(() => {});
+      const reenviarSpy = jest.spyOn(component, 'reenviarEmailNadaConsta').mockImplementation(() => undefined);
 
       const mockEvent = new Event('click');
       component.openOptions(mockEvent, 21);
@@ -457,7 +457,7 @@ describe('NadaConstaListComponent', () => {
     it('deve executar comando Invalidar e fechar menu ao clicar', fakeAsync(() => {
       const row = { id: 22, status: 'COMPLETED', usuario: { nome: 'Lucas' } } as any;
       component.objects = [row];
-      const invalidarSpy = jest.spyOn(component, 'abrirDialogConfirmarInvalidar').mockImplementation(() => {});
+      const invalidarSpy = jest.spyOn(component, 'abrirDialogConfirmarInvalidar').mockImplementation(() => undefined);
 
       const mockEvent = new Event('click');
       component.openOptions(mockEvent, 22);
@@ -473,7 +473,7 @@ describe('NadaConstaListComponent', () => {
     it('deve executar comando Revalidar e fechar menu ao clicar', fakeAsync(() => {
       const row = { id: 23, status: 'PENDING', usuario: { nome: 'Mariana' } } as any;
       component.objects = [row];
-      const revalidarSpy = jest.spyOn(component, 'verificarPendencias').mockImplementation(() => {});
+      const revalidarSpy = jest.spyOn(component, 'verificarPendencias').mockImplementation(() => undefined);
 
       const mockEvent = new Event('click');
       component.openOptions(mockEvent, 23);

--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -203,18 +203,6 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
    */
   public getInvalidando() { return this.invalidando(); }
 
-  /**
-   * Getter público para o sinal acaoErro
-   * @returns string | null
-   */
-  public getAcaoErro() { return this.acaoErro(); }
-
-  /**
-   * Getter público para o sinal acaoSucesso
-   * @returns string | null
-   */
-  public getAcaoSucesso() { return this.acaoSucesso(); }
-
   adicionar(): void {
     this.showAdicionarModal.set(true);
   }
@@ -309,13 +297,13 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
 
   protected readonly verificandoPendencias = signal<number | null>(null);
   protected readonly invalidando = signal<number | null>(null);
-  protected readonly acaoErro = signal<string | null>(null);
-  protected readonly acaoSucesso = signal<string | null>(null);
 
+  /**
+   * Verifica pendências do Nada Consta e atualiza o status.
+   * @param row Registro do Nada Consta
+   */
   verificarPendencias(row: NadaConsta): void {
     this.verificandoPendencias.set(row.id);
-    this.acaoErro.set(null);
-    this.acaoSucesso.set(null);
     this.service.verificarPendencias(row.id)
       .pipe(finalize(() => {
         this.verificandoPendencias.set(null);
@@ -323,21 +311,31 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       }))
       .subscribe({
         next: () => {
-          this.acaoSucesso.set('Pendências verificadas com sucesso.');
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Sucesso',
+            detail: 'Pendências verificadas com sucesso.'
+          });
           this.findAll();
           this.cdr.markForCheck();
         },
         error: (err) => {
-          this.acaoErro.set(err?.error?.message || 'Erro ao verificar pendências.');
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Erro',
+            detail: err?.error?.message || 'Erro ao verificar pendências.'
+          });
           this.cdr.markForCheck();
         }
       });
   }
 
+  /**
+   * Invalida o Nada Consta.
+   * @param row Registro do Nada Consta
+   */
   invalidar(row: NadaConsta): void {
     this.invalidando.set(row.id);
-    this.acaoErro.set(null);
-    this.acaoSucesso.set(null);
     this.service.invalidar(row.id)
       .pipe(finalize(() => {
         this.invalidando.set(null);
@@ -345,12 +343,20 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       }))
       .subscribe({
         next: () => {
-          this.acaoSucesso.set('Nada Consta invalidado com sucesso.');
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Sucesso',
+            detail: 'Nada Consta invalidado com sucesso.'
+          });
           this.findAll();
           this.cdr.markForCheck();
         },
         error: (err) => {
-          this.acaoErro.set(err?.error?.message || 'Erro ao invalidar Nada Consta.');
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Erro',
+            detail: err?.error?.message || 'Erro ao invalidar Nada Consta.'
+          });
           this.cdr.markForCheck();
         }
       });
@@ -379,33 +385,80 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
 
   public setVerificandoPendencias(val: number | null) { this.verificandoPendencias.set(val); }
   public setInvalidando(val: number | null) { this.invalidando.set(val); }
-  public setAcaoErro(val: string | null) { this.acaoErro.set(val); }
-  public setAcaoSucesso(val: string | null) { this.acaoSucesso.set(val); }
 
-  public menuVisible = signal<number | null>(null); // id da linha com menu aberto
   public menuLoading = signal(false);
-  public menuMessage = signal<string | null>(null);
 
-  // Chama API para imprimir PDF, abre em nova aba
+  /**
+   * Imprime o PDF do Nada Consta em uma nova aba do navegador.
+   * @param row Registro do Nada Consta
+   */
   public imprimirNadaConsta(row: NadaConsta) {
-    const url = `/nadaconsta/${row.id}/pdf`;
-    window.open(url, '_blank');
-    this.menuMessage.set('PDF aberto em nova aba.');
-    this.menuLoading.set(false);
+    this.actionsMenu().hide();
+    this.menuLoading.set(true);
+
+    this.service.downloadPdf(row.id)
+      .pipe(finalize(() => {
+        this.menuLoading.set(false);
+        this.cdr?.markForCheck();
+      }))
+      .subscribe({
+        next: (data) => {
+          // Cria um blob a partir do arraybuffer e abre em nova aba
+          const blob = new Blob([data], { type: 'application/pdf' });
+          const url = window.URL.createObjectURL(blob);
+          window.open(url, '_blank');
+
+          // Libera o objeto URL após um pequeno delay
+          setTimeout(() => window.URL.revokeObjectURL(url), 100);
+
+          this.messageService.add({
+            severity: 'success',
+            summary: 'PDF Gerado',
+            detail: 'O PDF foi aberto em uma nova aba.'
+          });
+          this.cdr?.markForCheck();
+        },
+        error: (err) => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Erro',
+            detail: err?.error?.message || 'Erro ao gerar PDF.'
+          });
+          this.cdr?.markForCheck();
+        }
+      });
   }
 
-  // Chama API para reenviar email
-  public async reenviarEmailNadaConsta(row: NadaConsta) {
+  /**
+   * Reenvia o email com o Nada Consta para o usuário.
+   * @param row Registro do Nada Consta
+   */
+  public reenviarEmailNadaConsta(row: NadaConsta) {
+    this.actionsMenu().hide();
     this.menuLoading.set(true);
-    this.menuMessage.set(null);
-    try {
-      await this.service.reenviarEmail(row.id).toPromise();
-      this.menuMessage.set('2ª via enviada com sucesso.');
-    } catch (err) {
-      this.menuMessage.set('Erro ao enviar 2ª via.');
-    } finally {
-      this.menuLoading.set(false);
-    }
+    this.service.reenviarEmail(row.id)
+      .pipe(finalize(() => {
+        this.menuLoading.set(false);
+        this.cdr?.markForCheck();
+      }))
+      .subscribe({
+        next: () => {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Email Enviado',
+            detail: '2ª via do Nada Consta enviada com sucesso.'
+          });
+          this.cdr?.markForCheck();
+        },
+        error: (err) => {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Erro',
+            detail: err?.error?.message || 'Erro ao enviar 2ª via.'
+          });
+          this.cdr?.markForCheck();
+        }
+      });
   }
 
   // Abre menu suspenso para linha
@@ -413,34 +466,53 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
     const nadaConsta = this.objects.find(e => e.id === id);
     this.contextMenuItems = [];
     if (!nadaConsta) return;
-    if (nadaConsta.status === 'completed') {
-      this.contextMenuItems.push({
-        label: 'Imprimir', icon: 'pi pi-print', command: () => this.imprimirNadaConsta(nadaConsta)
-      });
-      this.contextMenuItems.push({
-        label: '2ª via email', icon: 'pi pi-envelope', command: () => this.reenviarEmailNadaConsta(nadaConsta)
-      });
-      this.contextMenuItems.push({
-        label: 'Invalidar', icon: 'pi pi-ban', command: () => this.abrirDialogConfirmarInvalidar(nadaConsta)
-      });
-      this.contextMenuItems.push({
-        label: 'Cancelar', icon: 'pi pi-times', command: () => this.hideOptions()
-      });
-      this.actionsMenu().toggle(event);
-      this.cdr?.markForCheck();
-    } else if (nadaConsta.status === 'pending') {
-      this.contextMenuItems.push({
-        label: 'Revalidar', icon: 'pi pi-refresh', command: () => this.verificarPendencias(nadaConsta)
-      });
-      this.actionsMenu().toggle(event);
-      this.cdr?.markForCheck();
-    } else {
-      // status invalidated: não mostra popover nem ações
-      this.hideOptions();
-    }
-  }
 
-  hideOptions() {
-    this.actionsMenu().hide();
+    // Normaliza o status para uppercase para comparação consistente
+    const status = nadaConsta.status?.toUpperCase();
+
+    if (status === 'COMPLETED' || status === 'CONCLUIDO' || status === 'CONCLUÍDO') {
+      this.contextMenuItems.push({
+        label: 'Imprimir',
+        icon: 'pi pi-print',
+        command: () => this.imprimirNadaConsta(nadaConsta)
+      });
+      this.contextMenuItems.push({
+        label: '2ª via email',
+        icon: 'pi pi-envelope',
+        command: () => this.reenviarEmailNadaConsta(nadaConsta)
+      });
+      this.contextMenuItems.push({
+        label: 'Invalidar',
+        icon: 'pi pi-ban',
+        command: () => {
+          this.actionsMenu().hide();
+          this.abrirDialogConfirmarInvalidar(nadaConsta);
+        }
+      });
+      this.contextMenuItems.push({
+        label: 'Cancelar',
+        icon: 'pi pi-times',
+        command: () => this.actionsMenu().hide()
+      });
+      this.actionsMenu().toggle(event);
+      this.cdr?.markForCheck();
+    } else if (status === 'PENDING' || status === 'PENDENTE') {
+      this.contextMenuItems.push({
+        label: 'Revalidar',
+        icon: 'pi pi-refresh',
+        command: () => {
+          this.actionsMenu().hide();
+          this.verificarPendencias(nadaConsta);
+        }
+      });
+      this.contextMenuItems.push({
+        label: 'Cancelar',
+        icon: 'pi pi-times',
+        command: () => this.actionsMenu().hide()
+      });
+      this.actionsMenu().toggle(event);
+      this.cdr?.markForCheck();
+    }
+    // status invalidated: não mostra popover nem ações
   }
 }

--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -405,6 +405,7 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
     return {
       label: 'Cancelar',
       icon: 'pi pi-times',
+      ariaLabel: 'Fechar menu de ações',
       command: () => this.actionsMenu().hide()
     };
   }
@@ -425,9 +426,9 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       .subscribe({
         next: (data) => {
           const blob = new Blob([data], { type: 'application/pdf' });
-          const url = window.URL.createObjectURL(blob);
-          window.open(url, '_blank');
-          setTimeout(() => window.URL.revokeObjectURL(url), 100);
+          const url = globalThis.URL.createObjectURL(blob);
+          globalThis.open(url, '_blank');
+          setTimeout(() => globalThis.URL.revokeObjectURL(url), 100);
           this.showSuccessMessage('PDF Gerado', 'O PDF foi aberto em uma nova aba.');
         },
         error: (err) => this.showErrorMessage(err, 'Erro ao gerar PDF.')
@@ -497,16 +498,19 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       {
         label: 'Imprimir',
         icon: 'pi pi-print',
+        ariaLabel: 'Baixar e imprimir PDF do Nada Consta',
         command: () => this.imprimirNadaConsta(nadaConsta)
       },
       {
         label: '2ª via email',
         icon: 'pi pi-envelope',
+        ariaLabel: 'Reenviar segunda via do Nada Consta por email',
         command: () => this.reenviarEmailNadaConsta(nadaConsta)
       },
       {
         label: 'Invalidar',
         icon: 'pi pi-ban',
+        ariaLabel: 'Invalidar este Nada Consta',
         command: () => {
           this.actionsMenu().hide();
           this.abrirDialogConfirmarInvalidar(nadaConsta);
@@ -526,6 +530,7 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       {
         label: 'Revalidar',
         icon: 'pi pi-refresh',
+        ariaLabel: 'Verificar pendências e revalidar Nada Consta',
         command: () => {
           this.actionsMenu().hide();
           this.verificarPendencias(nadaConsta);

--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -311,22 +311,10 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       }))
       .subscribe({
         next: () => {
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Sucesso',
-            detail: 'Pendências verificadas com sucesso.'
-          });
+          this.showSuccessMessage('Sucesso', 'Pendências verificadas com sucesso.');
           this.findAll();
-          this.cdr.markForCheck();
         },
-        error: (err) => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Erro',
-            detail: err?.error?.message || 'Erro ao verificar pendências.'
-          });
-          this.cdr.markForCheck();
-        }
+        error: (err) => this.showErrorMessage(err, 'Erro ao verificar pendências.')
       });
   }
 
@@ -343,22 +331,10 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       }))
       .subscribe({
         next: () => {
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Sucesso',
-            detail: 'Nada Consta invalidado com sucesso.'
-          });
+          this.showSuccessMessage('Sucesso', 'Nada Consta invalidado com sucesso.');
           this.findAll();
-          this.cdr.markForCheck();
         },
-        error: (err) => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Erro',
-            detail: err?.error?.message || 'Erro ao invalidar Nada Consta.'
-          });
-          this.cdr.markForCheck();
-        }
+        error: (err) => this.showErrorMessage(err, 'Erro ao invalidar Nada Consta.')
       });
   }
 
@@ -389,6 +365,51 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
   public menuLoading = signal(false);
 
   /**
+   * Exibe mensagem de sucesso usando o MessageService.
+   * @param summary Título da mensagem
+   * @param detail Detalhes da mensagem
+   */
+  private showSuccessMessage(summary: string, detail: string): void {
+    this.messageService.add({ severity: 'success', summary, detail });
+    this.cdr?.markForCheck();
+  }
+
+  /**
+   * Exibe mensagem de erro usando o MessageService.
+   * @param err Objeto de erro da requisição
+   * @param defaultMessage Mensagem padrão caso não haja mensagem no erro
+   */
+  private showErrorMessage(err: any, defaultMessage: string): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Erro',
+      detail: err?.error?.message || defaultMessage
+    });
+    this.cdr?.markForCheck();
+  }
+
+  /**
+   * Abre o menu de ações após construir os itens.
+   * @param event Evento do clique
+   */
+  private openActionsMenu(event: Event): void {
+    this.actionsMenu().toggle(event);
+    this.cdr?.markForCheck();
+  }
+
+  /**
+   * Cria o item de menu "Cancelar" padrão.
+   * @returns MenuItem configurado para fechar o menu
+   */
+  private createCancelMenuItem(): MenuItem {
+    return {
+      label: 'Cancelar',
+      icon: 'pi pi-times',
+      command: () => this.actionsMenu().hide()
+    };
+  }
+
+  /**
    * Imprime o PDF do Nada Consta em uma nova aba do navegador.
    * @param row Registro do Nada Consta
    */
@@ -403,29 +424,13 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       }))
       .subscribe({
         next: (data) => {
-          // Cria um blob a partir do arraybuffer e abre em nova aba
           const blob = new Blob([data], { type: 'application/pdf' });
           const url = window.URL.createObjectURL(blob);
           window.open(url, '_blank');
-
-          // Libera o objeto URL após um pequeno delay
           setTimeout(() => window.URL.revokeObjectURL(url), 100);
-
-          this.messageService.add({
-            severity: 'success',
-            summary: 'PDF Gerado',
-            detail: 'O PDF foi aberto em uma nova aba.'
-          });
-          this.cdr?.markForCheck();
+          this.showSuccessMessage('PDF Gerado', 'O PDF foi aberto em uma nova aba.');
         },
-        error: (err) => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Erro',
-            detail: err?.error?.message || 'Erro ao gerar PDF.'
-          });
-          this.cdr?.markForCheck();
-        }
+        error: (err) => this.showErrorMessage(err, 'Erro ao gerar PDF.')
       });
   }
 
@@ -442,77 +447,91 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
         this.cdr?.markForCheck();
       }))
       .subscribe({
-        next: () => {
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Email Enviado',
-            detail: '2ª via do Nada Consta enviada com sucesso.'
-          });
-          this.cdr?.markForCheck();
-        },
-        error: (err) => {
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Erro',
-            detail: err?.error?.message || 'Erro ao enviar 2ª via.'
-          });
-          this.cdr?.markForCheck();
-        }
+        next: () => this.showSuccessMessage('Email Enviado', '2ª via do Nada Consta enviada com sucesso.'),
+        error: (err) => this.showErrorMessage(err, 'Erro ao enviar 2ª via.')
       });
   }
 
-  // Abre menu suspenso para linha
+  /**
+   * Abre menu suspenso para linha com ações baseadas no status.
+   * @param event Evento do clique
+   * @param id ID do registro
+   */
   public openOptions(event: Event, id: number): void {
     const nadaConsta = this.objects.find(e => e.id === id);
-    this.contextMenuItems = [];
     if (!nadaConsta) return;
 
-    // Normaliza o status para uppercase para comparação consistente
+    this.contextMenuItems = this.buildContextMenuItems(nadaConsta);
+
+    if (this.contextMenuItems.length > 0) {
+      this.openActionsMenu(event);
+    }
+  }
+
+  /**
+   * Constrói os itens do menu contextual baseado no status do Nada Consta.
+   * @param nadaConsta Registro do Nada Consta
+   * @returns Array de MenuItems
+   */
+  private buildContextMenuItems(nadaConsta: NadaConsta): MenuItem[] {
     const status = nadaConsta.status?.toUpperCase();
 
     if (status === 'COMPLETED' || status === 'CONCLUIDO' || status === 'CONCLUÍDO') {
-      this.contextMenuItems.push({
+      return this.buildCompletedMenuItems(nadaConsta);
+    }
+
+    if (status === 'PENDING' || status === 'PENDENTE') {
+      return this.buildPendingMenuItems(nadaConsta);
+    }
+
+    return [];
+  }
+
+  /**
+   * Constrói itens do menu para status COMPLETED.
+   * @param nadaConsta Registro do Nada Consta
+   * @returns Array de MenuItems
+   */
+  private buildCompletedMenuItems(nadaConsta: NadaConsta): MenuItem[] {
+    return [
+      {
         label: 'Imprimir',
         icon: 'pi pi-print',
         command: () => this.imprimirNadaConsta(nadaConsta)
-      });
-      this.contextMenuItems.push({
+      },
+      {
         label: '2ª via email',
         icon: 'pi pi-envelope',
         command: () => this.reenviarEmailNadaConsta(nadaConsta)
-      });
-      this.contextMenuItems.push({
+      },
+      {
         label: 'Invalidar',
         icon: 'pi pi-ban',
         command: () => {
           this.actionsMenu().hide();
           this.abrirDialogConfirmarInvalidar(nadaConsta);
         }
-      });
-      this.contextMenuItems.push({
-        label: 'Cancelar',
-        icon: 'pi pi-times',
-        command: () => this.actionsMenu().hide()
-      });
-      this.actionsMenu().toggle(event);
-      this.cdr?.markForCheck();
-    } else if (status === 'PENDING' || status === 'PENDENTE') {
-      this.contextMenuItems.push({
+      },
+      this.createCancelMenuItem()
+    ];
+  }
+
+  /**
+   * Constrói itens do menu para status PENDING.
+   * @param nadaConsta Registro do Nada Consta
+   * @returns Array de MenuItems
+   */
+  private buildPendingMenuItems(nadaConsta: NadaConsta): MenuItem[] {
+    return [
+      {
         label: 'Revalidar',
         icon: 'pi pi-refresh',
         command: () => {
           this.actionsMenu().hide();
           this.verificarPendencias(nadaConsta);
         }
-      });
-      this.contextMenuItems.push({
-        label: 'Cancelar',
-        icon: 'pi pi-times',
-        command: () => this.actionsMenu().hide()
-      });
-      this.actionsMenu().toggle(event);
-      this.cdr?.markForCheck();
-    }
-    // status invalidated: não mostra popover nem ações
+      },
+      this.createCancelMenuItem()
+    ];
   }
 }

--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, forwardRef, signal, inject, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, forwardRef, signal, inject, ChangeDetectionStrategy, ChangeDetectorRef, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DialogModule } from 'primeng/dialog';
@@ -20,6 +20,9 @@ import { finalize } from 'rxjs';
 import { getNadaConstaStatusLabel, getNadaConstaStatusSeverity } from '../../framework/utils/status-label.util';
 import { createTableConfig } from '../../framework/utils/table-config.factory';
 import { TableEmptyStateComponent } from '../../framework/component/table-empty-state.component';
+import { MenuItem } from 'primeng/api';
+import { MenuModule } from 'primeng/menu';
+import { Popover, PopoverModule } from 'primeng/popover';
 
 @Component({
   selector: 'app-nada-consta-list',
@@ -42,11 +45,16 @@ import { TableEmptyStateComponent } from '../../framework/component/table-empty-
     IconFieldModule,
     InputIconModule,
     TableFilterCaptionComponent,
-    TableEmptyStateComponent
+    TableEmptyStateComponent,
+    MenuModule,
+    PopoverModule
   ],
   providers: [{ provide: PrimeCrudListComponent, useExisting: forwardRef(() => NadaConstaListComponent) }]
 })
 export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, number> {
+  readonly actionsMenu = viewChild.required<Popover>('actionsMenu');
+  contextMenuItems: MenuItem[] = [];
+
   protected override columnsTable: string[] = [
     'id',
     'usuarioUsername',
@@ -373,4 +381,66 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
   public setInvalidando(val: number | null) { this.invalidando.set(val); }
   public setAcaoErro(val: string | null) { this.acaoErro.set(val); }
   public setAcaoSucesso(val: string | null) { this.acaoSucesso.set(val); }
+
+  public menuVisible = signal<number | null>(null); // id da linha com menu aberto
+  public menuLoading = signal(false);
+  public menuMessage = signal<string | null>(null);
+
+  // Chama API para imprimir PDF, abre em nova aba
+  public imprimirNadaConsta(row: NadaConsta) {
+    const url = `/nadaconsta/${row.id}/pdf`;
+    window.open(url, '_blank');
+    this.menuMessage.set('PDF aberto em nova aba.');
+    this.menuLoading.set(false);
+  }
+
+  // Chama API para reenviar email
+  public async reenviarEmailNadaConsta(row: NadaConsta) {
+    this.menuLoading.set(true);
+    this.menuMessage.set(null);
+    try {
+      await this.service.reenviarEmail(row.id).toPromise();
+      this.menuMessage.set('2ª via enviada com sucesso.');
+    } catch (err) {
+      this.menuMessage.set('Erro ao enviar 2ª via.');
+    } finally {
+      this.menuLoading.set(false);
+    }
+  }
+
+  // Abre menu suspenso para linha
+  public openOptions(event: Event, id: number): void {
+    const nadaConsta = this.objects.find(e => e.id === id);
+    this.contextMenuItems = [];
+    if (!nadaConsta) return;
+    if (nadaConsta.status === 'completed') {
+      this.contextMenuItems.push({
+        label: 'Imprimir', icon: 'pi pi-print', command: () => this.imprimirNadaConsta(nadaConsta)
+      });
+      this.contextMenuItems.push({
+        label: '2ª via email', icon: 'pi pi-envelope', command: () => this.reenviarEmailNadaConsta(nadaConsta)
+      });
+      this.contextMenuItems.push({
+        label: 'Invalidar', icon: 'pi pi-ban', command: () => this.abrirDialogConfirmarInvalidar(nadaConsta)
+      });
+      this.contextMenuItems.push({
+        label: 'Cancelar', icon: 'pi pi-times', command: () => this.hideOptions()
+      });
+      this.actionsMenu().toggle(event);
+      this.cdr?.markForCheck();
+    } else if (nadaConsta.status === 'pending') {
+      this.contextMenuItems.push({
+        label: 'Revalidar', icon: 'pi pi-refresh', command: () => this.verificarPendencias(nadaConsta)
+      });
+      this.actionsMenu().toggle(event);
+      this.cdr?.markForCheck();
+    } else {
+      // status invalidated: não mostra popover nem ações
+      this.hideOptions();
+    }
+  }
+
+  hideOptions() {
+    this.actionsMenu().hide();
+  }
 }

--- a/src/app/nada-consta/nada-consta.service.spec.ts
+++ b/src/app/nada-consta/nada-consta.service.spec.ts
@@ -187,4 +187,247 @@ describe('NadaConstaService', () => {
     const req = httpMock.expectOne(r => r.url.includes('/nadaconsta/invalidar/999'));
     req.flush('Not found', {status: 404, statusText: 'Not Found'});
   });
+
+  describe('downloadPdf', () => {
+    it('deve baixar PDF como ArrayBuffer', () => {
+      const id = 15;
+      const mockArrayBuffer = new ArrayBuffer(1024);
+
+      service.downloadPdf(id).subscribe(data => {
+        expect(data).toEqual(mockArrayBuffer);
+        expect(data.byteLength).toBe(1024);
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/pdf`));
+      expect(req.request.method).toBe('GET');
+      expect(req.request.responseType).toBe('arraybuffer');
+      req.flush(mockArrayBuffer);
+    });
+
+    it('deve construir URL correta para download de PDF', () => {
+      const id = 42;
+      const mockArrayBuffer = new ArrayBuffer(512);
+
+      service.downloadPdf(id).subscribe();
+
+      const req = httpMock.expectOne(r => {
+        return r.url.includes('/nadaconsta/') && r.url.includes(`${id}/pdf`);
+      });
+      expect(req.request.url).toContain(`${id}/pdf`);
+      req.flush(mockArrayBuffer);
+    });
+
+    it('deve tratar erro ao baixar PDF', () => {
+      const id = 999;
+
+      service.downloadPdf(id).subscribe({
+        next: () => fail('Deveria falhar'),
+        error: err => {
+          expect(err.status).toBe(404);
+          expect(err.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/pdf`));
+      req.error(new ProgressEvent('error'), {status: 404, statusText: 'Not Found'});
+    });
+
+    it('deve tratar erro 403 (não autorizado) ao baixar PDF', () => {
+      const id = 50;
+
+      service.downloadPdf(id).subscribe({
+        next: () => fail('Deveria falhar'),
+        error: err => {
+          expect(err.status).toBe(403);
+          expect(err.statusText).toBe('Forbidden');
+        }
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/pdf`));
+      req.error(new ProgressEvent('error'), {status: 403, statusText: 'Forbidden'});
+    });
+
+    it('deve baixar PDF de tamanho zero (edge case)', () => {
+      const id = 20;
+      const emptyArrayBuffer = new ArrayBuffer(0);
+
+      service.downloadPdf(id).subscribe(data => {
+        expect(data).toEqual(emptyArrayBuffer);
+        expect(data.byteLength).toBe(0);
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/pdf`));
+      req.flush(emptyArrayBuffer);
+    });
+  });
+
+  describe('reenviarEmail', () => {
+    it('deve reenviar email com sucesso', () => {
+      const id = 25;
+      const mockResponse = {mensagem: 'Email reenviado com sucesso'};
+
+      service.reenviarEmail(id).subscribe(resp => {
+        expect(resp).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/reenvio`));
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({});
+      req.flush(mockResponse);
+    });
+
+    it('deve construir URL correta para reenvio de email', () => {
+      const id = 30;
+      const mockResponse = {status: 'ok'};
+
+      service.reenviarEmail(id).subscribe();
+
+      const req = httpMock.expectOne(r => {
+        return r.url.includes('/nadaconsta/') && r.url.includes(`${id}/reenvio`);
+      });
+      expect(req.request.url).toContain(`${id}/reenvio`);
+      req.flush(mockResponse);
+    });
+
+    it('deve enviar corpo vazio na requisição POST', () => {
+      const id = 35;
+
+      service.reenviarEmail(id).subscribe();
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/reenvio`));
+      expect(req.request.body).toEqual({});
+      req.flush({});
+    });
+
+    it('deve tratar erro ao reenviar email', () => {
+      const id = 999;
+
+      service.reenviarEmail(id).subscribe({
+        next: () => fail('Deveria falhar'),
+        error: err => {
+          expect(err.status).toBe(404);
+          expect(err.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/reenvio`));
+      req.flush('Nada Consta not found', {status: 404, statusText: 'Not Found'});
+    });
+
+    it('deve tratar erro 403 (não autorizado) ao reenviar email', () => {
+      const id = 40;
+
+      service.reenviarEmail(id).subscribe({
+        next: () => fail('Deveria falhar'),
+        error: err => {
+          expect(err.status).toBe(403);
+          expect(err.statusText).toBe('Forbidden');
+        }
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/reenvio`));
+      req.flush('Forbidden', {status: 403, statusText: 'Forbidden'});
+    });
+
+    it('deve tratar erro 400 (email inválido) ao reenviar', () => {
+      const id = 45;
+
+      service.reenviarEmail(id).subscribe({
+        next: () => fail('Deveria falhar'),
+        error: err => {
+          expect(err.status).toBe(400);
+          expect(err.error).toEqual({message: 'Email do usuário inválido'});
+        }
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/reenvio`));
+      req.flush(
+        {message: 'Email do usuário inválido'},
+        {status: 400, statusText: 'Bad Request'}
+      );
+    });
+
+    it('deve tratar erro 500 (falha no servidor de email)', () => {
+      const id = 50;
+
+      service.reenviarEmail(id).subscribe({
+        next: () => fail('Deveria falhar'),
+        error: err => {
+          expect(err.status).toBe(500);
+          expect(err.error).toEqual({message: 'Erro ao enviar email'});
+        }
+      });
+
+      const req = httpMock.expectOne(r => r.url.includes(`/nadaconsta/${id}/reenvio`));
+      req.flush(
+        {message: 'Erro ao enviar email'},
+        {status: 500, statusText: 'Internal Server Error'}
+      );
+    });
+  });
+
+  describe('Integração entre métodos', () => {
+    it('deve permitir múltiplas operações em sequência', () => {
+      const id = 60;
+
+      // Verificar pendências
+      service.verificarPendencias(id).subscribe();
+      const req1 = httpMock.expectOne(r => r.url.includes('verificar-pendencias'));
+      req1.flush({id, status: 'COMPLETED'});
+
+      // Baixar PDF
+      service.downloadPdf(id).subscribe();
+      const req2 = httpMock.expectOne(r => r.url.includes('/pdf'));
+      req2.flush(new ArrayBuffer(100));
+
+      // Reenviar email
+      service.reenviarEmail(id).subscribe();
+      const req3 = httpMock.expectOne(r => r.url.includes('/reenvio'));
+      req3.flush({});
+
+      expect(true).toBe(true); // Verifica que não houve erros
+    });
+
+    it('deve manter independência entre chamadas simultâneas', () => {
+      const id1 = 70;
+      const id2 = 71;
+
+      service.downloadPdf(id1).subscribe();
+      service.reenviarEmail(id2).subscribe();
+
+      const reqs = httpMock.match(() => true);
+      expect(reqs.length).toBe(2);
+
+      const pdfReq = reqs.find(r => r.request.url.includes('/pdf'));
+      const emailReq = reqs.find(r => r.request.url.includes('/reenvio'));
+
+      expect(pdfReq).toBeDefined();
+      expect(emailReq).toBeDefined();
+
+      pdfReq?.flush(new ArrayBuffer(50));
+      emailReq?.flush({});
+    });
+  });
+
+  describe('Validação de URLs', () => {
+    it('deve usar a mesma base URL para todos os endpoints', () => {
+      service.consultarNadaConsta(1).subscribe();
+      const req1 = httpMock.expectOne(() => true);
+      const baseUrl1 = req1.request.url.split('/nadaconsta/')[0];
+      req1.flush({});
+
+      service.downloadPdf(2).subscribe();
+      const req2 = httpMock.expectOne(() => true);
+      const baseUrl2 = req2.request.url.split('/nadaconsta/')[0];
+      req2.flush(new ArrayBuffer(0));
+
+      service.reenviarEmail(3).subscribe();
+      const req3 = httpMock.expectOne(() => true);
+      const baseUrl3 = req3.request.url.split('/nadaconsta/')[0];
+      req3.flush({});
+
+      expect(baseUrl1).toBe(baseUrl2);
+      expect(baseUrl2).toBe(baseUrl3);
+    });
+  });
 });

--- a/src/app/nada-consta/nada-consta.service.ts
+++ b/src/app/nada-consta/nada-consta.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import {environment} from '../../environments/environment';
 import {CrudService} from "../framework/service/crud.service";
 
@@ -35,10 +35,9 @@ export interface NadaConsta {
 
 @Injectable({ providedIn: 'root' })
 export class NadaConstaService extends CrudService<NadaConsta, number> {
-  protected http: HttpClient;
-  constructor(http: HttpClient) {
+  constructor() {
+    const http = inject(HttpClient);
     super(`${environment.api_url}nadaconsta/`, http);
-    this.http = http;
   }
 
   /**

--- a/src/app/nada-consta/nada-consta.service.ts
+++ b/src/app/nada-consta/nada-consta.service.ts
@@ -85,11 +85,25 @@ export class NadaConstaService extends CrudService<NadaConsta, number> {
     return this.http.put<NadaConsta>(`${this.url}invalidar/${id}`, {});
   }
 
+  /**
+   * Baixa o PDF do Nada Consta.
+   * @param {number} id Identificador do registro
+   * @returns Resultado da requisição com o PDF em formato arraybuffer
+   * @example
+   * this.nadaConstaService.downloadPdf(123).subscribe(...)
+   */
   downloadPdf(id: number) {
-    return this.http.get(`/nadaconsta/${id}/pdf`, { responseType: 'arraybuffer' });
+    return this.http.get(`${this.url}${id}/pdf`, { responseType: 'arraybuffer' });
   }
 
+  /**
+   * Reenvia o email com o Nada Consta.
+   * @param {number} id Identificador do registro
+   * @returns Resultado da requisição
+   * @example
+   * this.nadaConstaService.reenviarEmail(123).subscribe(...)
+   */
   reenviarEmail(id: number) {
-    return this.http.post(`/nadaconsta/${id}/reenvia`, {});
+    return this.http.post(`${this.url}${id}/reenvio`, {});
   }
 }

--- a/src/app/nada-consta/nada-consta.service.ts
+++ b/src/app/nada-consta/nada-consta.service.ts
@@ -1,5 +1,5 @@
-import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 import {environment} from '../../environments/environment';
 import {CrudService} from "../framework/service/crud.service";
 
@@ -35,15 +35,16 @@ export interface NadaConsta {
 
 @Injectable({ providedIn: 'root' })
 export class NadaConstaService extends CrudService<NadaConsta, number> {
-  constructor() {
-    const http = inject(HttpClient);
+  protected http: HttpClient;
+  constructor(http: HttpClient) {
     super(`${environment.api_url}nadaconsta/`, http);
+    this.http = http;
   }
 
   /**
    * Consulta um Nada Consta pelo id.
    * @param {number} id Identificador do registro
-   * @returns {Observable<NadaConsta>} Observable do resultado da requisição
+   * @returns Resultado da requisição
    * @example
    * this.nadaConstaService.consultarNadaConsta(123).subscribe(...)
    */
@@ -54,7 +55,7 @@ export class NadaConstaService extends CrudService<NadaConsta, number> {
   /**
    * Solicita um Nada Consta pelo documento.
    * @param {string} documento Documento do usuário
-   * @returns {Observable<any>} Observable do resultado da requisição
+   * @returns Resultado da requisição
    * @example
    * this.nadaConstaService.solicitar('12345678900').subscribe(...)
    */
@@ -65,7 +66,7 @@ export class NadaConstaService extends CrudService<NadaConsta, number> {
   /**
    * Verifica pendências do Nada Consta pelo id.
    * @param {number} id Identificador do registro
-   * @returns {Observable<NadaConsta>} Observable do resultado da requisição
+   * @returns Resultado da requisição
    * @example
    * this.nadaConstaService.verificarPendencias(123).subscribe(...)
    */
@@ -76,11 +77,19 @@ export class NadaConstaService extends CrudService<NadaConsta, number> {
   /**
    * Invalida o Nada Consta pelo id.
    * @param {number} id Identificador do registro
-   * @returns {Observable<NadaConsta>} Observable do resultado da requisição
+   * @returns Resultado da requisição
    * @example
    * this.nadaConstaService.invalidar(123).subscribe(...)
    */
   invalidar(id: number) {
     return this.http.put<NadaConsta>(`${this.url}invalidar/${id}`, {});
+  }
+
+  downloadPdf(id: number) {
+    return this.http.get(`/nadaconsta/${id}/pdf`, { responseType: 'arraybuffer' });
+  }
+
+  reenviarEmail(id: number) {
+    return this.http.post(`/nadaconsta/${id}/reenvia`, {});
   }
 }


### PR DESCRIPTION
### Description

This pull request introduces the following key changes:

- Added PDF download functionality.
- Added email resend functionality to the Nada Consta service.
- Updated related UI components to reflect the changes.
- Included comprehensive tests for both added features.

These updates enhance user experience and improve service reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Novas Funcionalidades**
  * Menu contextual unificado por status com ações dinâmicas (Imprimir, 2ª via email, Invalidar, Revalidar, Cancelar).
  * Ação de imprimir PDF abre em nova aba; reenvio de email disponível pelo menu.
  * Linhas interativas com suporte a teclado (Enter/Espaço) e foco; menu global de ações.

* **Melhorias**
  * Feedback via toasts estruturados para sucessos e erros.
  * Indicadores de carregamento nas ações do menu; interação isolada para evitar propagação de eventos.

* **Tests**
  * Cobertura ampliada para PDF, reenvio de email, menus por status, normalização de status e múltiplos cenários de erro.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->