### PR TITLE
Add isReadOnly property to reserva list component

### DIFF
--- a/src/app/reserva/reserva.list.component.ts
+++ b/src/app/reserva/reserva.list.component.ts
@@ -39,6 +39,7 @@ export class ReservaListComponent extends PrimeCrudListComponent<Reserva, number
 
   // Override: Todos os usuários autenticados podem criar reservas (alunos/professores incluídos)
   override readonly canCreate = computed(() => true);
+  override readonly isReadOnly = computed(() => false);
 
   readonly actionsMenu = viewChild.required<Popover>('actionsMenu');
   contextMenuItems: MenuItem[] = [];

--- a/src/app/reserva/reserva.list.component.ts
+++ b/src/app/reserva/reserva.list.component.ts
@@ -39,6 +39,9 @@ export class ReservaListComponent extends PrimeCrudListComponent<Reserva, number
 
   // Override: Todos os usuários autenticados podem criar reservas (alunos/professores incluídos)
   override readonly canCreate = computed(() => true);
+
+  // Override: Reservas nunca devem ser globalmente readonly; bloqueio global é tratado em outro lugar
+  // Apenas a regra isAlunoOrProfessor() bloqueia ações para alunos/professores
   override readonly isReadOnly = computed(() => false);
 
   readonly actionsMenu = viewChild.required<Popover>('actionsMenu');


### PR DESCRIPTION
This pull request introduces the `isReadOnly` property to the reserva list component to enhance state management and provide better control over component behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções de Bugs**
  * Restauradas ações na interface de reservas: o modo global somente-leitura foi desativado, permitindo novamente interações previamente bloqueadas, mantendo controles por função (aluno/professor) para autorizações.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->