### PR TITLE
Override deletion permission to prevent item removal in nada consta list

### DIFF
--- a/src/app/nada-consta/list/nada-consta-list.component.ts
+++ b/src/app/nada-consta/list/nada-consta-list.component.ts
@@ -630,4 +630,7 @@ export class NadaConstaListComponent extends PrimeCrudListComponent<NadaConsta, 
       this.createCancelMenuItem()
     ];
   }
+
+  // Sobrescreve permissão de exclusão para nunca permitir exclusão nesta tela
+  override readonly canDelete = signal(false);
 }


### PR DESCRIPTION
This pull request introduces a feature to override deletion permissions, ensuring that items in the "nada consta" list cannot be removed. This update safeguards critical data integrity in the listed items.

---

### Checklist:

- [ ] Tests added/updated
- [ ] Documentation added/updated
- [ ] Code adheres to coding standards
- [ ] Performance considerations evaluated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lançamento

* **Bug Fixes**
  * Desabilitada a funcionalidade de exclusão na tela específica, garantindo que registros não possam ser removidos indevidamente nesta seção.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->